### PR TITLE
Fix for Issue #25

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/AbstractDocumentSource.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/AbstractDocumentSource.java
@@ -24,224 +24,232 @@ import com.wordnik.swagger.core.Documentation;
 
 /**
  * Created with IntelliJ IDEA.
- *
+ * 
  * @author: chekong 05/13/2013
  */
 public abstract class AbstractDocumentSource {
 
-    protected final LogAdapter LOG;
+  protected final LogAdapter LOG;
 
-    private final String outputPath;
+  private final String outputPath;
 
-    private final String templatePath;
+  private final String templatePath;
 
-    private final String mustacheFileRoot;
+  private final String mustacheFileRoot;
 
-    private final String swaggerPath;
+  private final String swaggerPath;
 
-    protected Documentation serviceDocument;
+  protected Documentation serviceDocument;
 
-    List<Documentation> validDocuments = new LinkedList<Documentation>();
+  List<Documentation> validDocuments = new LinkedList<Documentation>();
 
-    private String basePath;
+  private String basePath;
 
-    private String apiVersion;
+  private String apiVersion;
 
-    private ObjectMapper mapper = new ObjectMapper();
+  private final ObjectMapper mapper = new ObjectMapper();
 
-    private OutputTemplate outputTemplate;
+  private OutputTemplate outputTemplate;
 
-    private boolean useOutputFlatStructure;
+  private final boolean useOutputFlatStructure;
 
-    public AbstractDocumentSource(LogAdapter logAdapter, String outputPath, String outputTpl, String swaggerOutput, String mustacheFileRoot, boolean useOutputFlatStructure1) {
-        LOG = logAdapter;
-        this.outputPath = outputPath;
-        this.templatePath = outputTpl;
-        this.mustacheFileRoot = mustacheFileRoot;
-        this.useOutputFlatStructure = useOutputFlatStructure1;
-        this.swaggerPath = swaggerOutput;
+  public AbstractDocumentSource(LogAdapter logAdapter, String outputPath, String outputTpl,
+      String swaggerOutput, String mustacheFileRoot, boolean useOutputFlatStructure1) {
+    LOG = logAdapter;
+    this.outputPath = outputPath;
+    this.templatePath = outputTpl;
+    this.mustacheFileRoot = mustacheFileRoot;
+    this.useOutputFlatStructure = useOutputFlatStructure1;
+    this.swaggerPath = swaggerOutput;
+  }
+
+  protected void acceptDocument(Documentation doc) {
+    validDocuments.add(doc);
+  }
+
+  private void cleanupOlds(File dir) {
+    if (dir.listFiles() != null) {
+      for (File f : dir.listFiles()) {
+        if (f.getName().endsWith("json")) {
+          f.delete();
+        }
+      }
+    }
+  }
+
+  protected File createFile(File dir, String outputResourcePath) throws IOException {
+    File serviceFile;
+    int i = outputResourcePath.lastIndexOf("/");
+    if (i != -1) {
+      String fileName = outputResourcePath.substring(i + 1);
+      String subDir = outputResourcePath.substring(0, i);
+      File finalDirectory = new File(dir, subDir);
+      finalDirectory.mkdirs();
+      serviceFile = new File(finalDirectory, fileName);
+    } else {
+      serviceFile = new File(dir, outputResourcePath);
+    }
+    while (!serviceFile.createNewFile()) {
+      serviceFile.delete();
+    }
+    LOG.info("Creating file " + serviceFile.getAbsolutePath());
+    return serviceFile;
+  }
+
+  public String getApiVersion() {
+    return apiVersion;
+  }
+
+  public String getBasePath() {
+    return basePath;
+  }
+
+  private DefaultMustacheFactory getMustacheFactory() {
+    if (mustacheFileRoot == null) {
+      return new DefaultMustacheFactory();
+    } else {
+      return new DefaultMustacheFactory(new File(mustacheFileRoot));
+    }
+  }
+
+  public OutputTemplate getOutputTemplate() {
+    return outputTemplate;
+  }
+
+  private URI getTemplateUri() throws GenerateException {
+    URI uri = null;
+    try {
+      uri = new URI(templatePath);
+    } catch (URISyntaxException e) {
+      File file = new File(templatePath);
+      if (!file.exists()) {
+        throw new GenerateException(
+            "Template "
+                + file.getAbsoluteFile()
+                + " not found. You can go to https://github.com/kongchen/api-doc-template to get templates.");
+      }
+      uri = file.toURI();
+    }
+    if (!uri.isAbsolute()) {
+      File file = new File(templatePath);
+      if (!file.exists()) {
+        throw new GenerateException(
+            "Template "
+                + file.getAbsoluteFile()
+                + " not found. You can go to https://github.com/kongchen/api-doc-template to get templates.");
+      } else {
+        uri = new File(templatePath).toURI();
+      }
+    }
+    return uri;
+  }
+
+  public List<Documentation> getValidDocuments() {
+    return validDocuments;
+  }
+
+  public abstract void loadDocuments() throws Exception, GenerateException;
+
+  public OutputTemplate prepareMustacheTemplate() {
+    this.outputTemplate = new OutputTemplate(this);
+    return outputTemplate;
+
+  }
+
+  protected String resourcePathToFilename(String resourcePath) {
+    if (resourcePath == null) {
+      return "service.json";
+    }
+    String name = resourcePath;
+    if (name.startsWith("/")) {
+      name = name.substring(1);
+    }
+    if (name.endsWith("/")) {
+      name = name.substring(0, name.length() - 1);
     }
 
-    public abstract void loadDocuments() throws Exception, GenerateException;
-
-    public String getBasePath() {
-        return basePath;
+    if (useOutputFlatStructure) {
+      name = name.replaceAll("/", "_");
     }
 
-    public void setBasePath(String basePath) {
-        this.basePath = basePath;
+    // Return the name without "*.json" extension so that swagger-ui can show it correctly
+    return name;
+  }
+
+  public void setApiVersion(String apiVersion) {
+    this.apiVersion = apiVersion;
+  }
+
+  public void setBasePath(String basePath) {
+    this.basePath = basePath;
+  }
+
+  public void toDocuments() throws GenerateException {
+    if (outputTemplate == null) {
+      prepareMustacheTemplate();
+    }
+    if (outputTemplate.getApiDocuments().isEmpty()) {
+      LOG.warn("nothing to write.");
+      return;
+    }
+    LOG.info("Writing doc to " + outputPath + "...");
+
+    FileOutputStream fileOutputStream = null;
+    try {
+      fileOutputStream = new FileOutputStream(outputPath);
+    } catch (FileNotFoundException e) {
+      throw new GenerateException(e);
+    }
+    OutputStreamWriter writer = new OutputStreamWriter(fileOutputStream, Charset.forName("UTF-8"));
+
+    try {
+      URL url = getTemplateUri().toURL();
+      InputStreamReader reader = new InputStreamReader(url.openStream(), Charset.forName("UTF-8"));
+      Mustache mustache = getMustacheFactory().compile(reader, templatePath);
+
+      mustache.execute(writer, outputTemplate).flush();
+      writer.close();
+      LOG.info("Done!");
+    } catch (MalformedURLException e) {
+      throw new GenerateException(e);
+    } catch (IOException e) {
+      throw new GenerateException(e);
+    }
+  }
+
+  public void toSwaggerDocuments() throws GenerateException {
+    if (swaggerPath == null) {
+      return;
+    }
+    File dir = new File(swaggerPath);
+    if (dir.isFile()) {
+      throw new GenerateException(String.format("Swagger-outputDirectory[%s] must be a directory!",
+          swaggerPath));
     }
 
-    public String getApiVersion() {
-        return apiVersion;
+    if (!dir.exists()) {
+      try {
+        FileUtils.forceMkdir(dir);
+      } catch (IOException e) {
+        throw new GenerateException(String.format("Create Swagger-outputDirectory[%s] failed.",
+            swaggerPath));
+      }
     }
+    cleanupOlds(dir);
 
-    public void setApiVersion(String apiVersion) {
-        this.apiVersion = apiVersion;
+    writeInDirectory(dir, serviceDocument);
+    for (Documentation doc : validDocuments) {
+      writeInDirectory(dir, doc);
     }
+  }
 
-    public OutputTemplate getOutputTemplate() {
-        return outputTemplate;
+  private void writeInDirectory(File dir, Documentation doc) throws GenerateException {
+    String filename = resourcePathToFilename(doc.getResourcePath());
+    try {
+      File serviceFile = createFile(dir, filename);
+      mapper.writerWithDefaultPrettyPrinter().writeValue(serviceFile, doc);
+    } catch (IOException e) {
+      throw new GenerateException(e);
     }
-
-    protected void acceptDocument(Documentation doc) {
-        validDocuments.add(doc);
-    }
-
-    public List<Documentation> getValidDocuments() {
-        return validDocuments;
-    }
-
-    public void toSwaggerDocuments() throws GenerateException {
-        if (swaggerPath == null) {
-            return;
-        }
-        File dir = new File(swaggerPath);
-        if (dir.isFile()) {
-            throw new GenerateException(String.format("Swagger-outputDirectory[%s] must be a directory!", swaggerPath));
-        }
-
-        if (!dir.exists()) {
-            try {
-                FileUtils.forceMkdir(dir);
-            } catch (IOException e) {
-                throw new GenerateException(String.format("Create Swagger-outputDirectory[%s] failed.", swaggerPath));
-            }
-        }
-        cleanupOlds(dir);
-
-        writeInDirectory(dir, serviceDocument);
-        for (Documentation doc : validDocuments) {
-            writeInDirectory(dir, doc);
-        }
-    }
-
-    private void cleanupOlds(File dir) {
-        if (dir.listFiles() != null) {
-            for (File f : dir.listFiles()) {
-                if (f.getName().endsWith("json")) {
-                    f.delete();
-                }
-            }
-        }
-    }
-
-    protected String resourcePathToFilename(String resourcePath) {
-        if (resourcePath == null) {
-            return "service.json";
-        }
-        String name = resourcePath;
-        if (name.startsWith("/")) {
-            name = name.substring(1);
-        }
-        if (name.endsWith("/")) {
-            name = name.substring(0, name.length() - 1);
-        }
-
-        if (useOutputFlatStructure) {
-            name = name.replaceAll("/", "_");
-        }
-
-        return name + ".json";
-    }
-
-    private void writeInDirectory(File dir, Documentation doc) throws GenerateException {
-        String filename = resourcePathToFilename(doc.getResourcePath());
-        try {
-            File serviceFile = createFile(dir, filename);
-            mapper.writerWithDefaultPrettyPrinter().writeValue(serviceFile, doc);
-        } catch (IOException e) {
-            throw new GenerateException(e);
-        }
-    }
-
-    protected File createFile(File dir, String outputResourcePath) throws IOException {
-        File serviceFile;
-        int i = outputResourcePath.lastIndexOf("/");
-        if (i != -1) {
-            String fileName = outputResourcePath.substring(i + 1);
-            String subDir = outputResourcePath.substring(0, i);
-            File finalDirectory = new File(dir, subDir);
-            finalDirectory.mkdirs();
-            serviceFile = new File(finalDirectory, fileName);
-        } else {
-            serviceFile = new File(dir, outputResourcePath);
-        }
-        while (!serviceFile.createNewFile()) {
-            serviceFile.delete();
-        }
-        LOG.info("Creating file " + serviceFile.getAbsolutePath());
-        return serviceFile;
-    }
-
-    public OutputTemplate prepareMustacheTemplate() {
-        this.outputTemplate = new OutputTemplate(this);
-        return outputTemplate;
-
-    }
-
-    public void toDocuments() throws GenerateException {
-        if (outputTemplate == null) {
-            prepareMustacheTemplate();
-        }
-        if (outputTemplate.getApiDocuments().isEmpty()) {
-            LOG.warn("nothing to write.");
-            return;
-        }
-        LOG.info("Writing doc to " + outputPath + "...");
-
-        FileOutputStream fileOutputStream = null;
-        try {
-            fileOutputStream = new FileOutputStream(outputPath);
-        } catch (FileNotFoundException e) {
-            throw new GenerateException(e);
-        }
-        OutputStreamWriter writer = new OutputStreamWriter(fileOutputStream, Charset.forName("UTF-8"));
-
-        try {
-            URL url = getTemplateUri().toURL();
-            InputStreamReader reader = new InputStreamReader(url.openStream(), Charset.forName("UTF-8"));
-            Mustache mustache = getMustacheFactory().compile(reader, templatePath);
-
-            mustache.execute(writer, outputTemplate).flush();
-            writer.close();
-            LOG.info("Done!");
-        } catch (MalformedURLException e) {
-            throw new GenerateException(e);
-        } catch (IOException e) {
-            throw new GenerateException(e);
-        }
-    }
-
-    private URI getTemplateUri() throws GenerateException {
-        URI uri = null;
-        try {
-            uri = new URI(templatePath);
-        } catch (URISyntaxException e) {
-            File file = new File(templatePath);
-            if (!file.exists()) {
-                throw new GenerateException("Template " + file.getAbsoluteFile()
-                        + " not found. You can go to https://github.com/kongchen/api-doc-template to get templates.");
-            }
-            uri = file.toURI();
-        }
-        if (!uri.isAbsolute()) {
-            File file = new File(templatePath);
-            if (!file.exists()) {
-                throw new GenerateException("Template " + file.getAbsoluteFile()
-                        + " not found. You can go to https://github.com/kongchen/api-doc-template to get templates.");
-            } else {
-                uri = new File(templatePath).toURI();
-            }
-        }
-        return uri;
-    }
-
-    private DefaultMustacheFactory getMustacheFactory() {
-        if (mustacheFileRoot == null) {
-            return new DefaultMustacheFactory();
-        } else {
-            return new DefaultMustacheFactory(new File(mustacheFileRoot));
-        }
-    }
+  }
 }

--- a/src/test/java/com/github/kongchen/swagger/docgen/AbstractDocumentSourceTest.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/AbstractDocumentSourceTest.java
@@ -11,43 +11,46 @@ import org.testng.annotations.Test;
 
 public class AbstractDocumentSourceTest {
 
-	public static final String OUTPUT_PATH = "foo/bar.json";
-	public static final String FLAT_OUTPUT_PATH = "foo_bar.json";
+  // Omit the '*.json' extension, so that swagger-ui can show it correctly.
 
-	@Test
-	public void testResourcePathToFilename() throws Exception {
-		AbstractDocumentSource abstractDocumentSource = getAbstractDocumentSource(true);
-		assertEquals(FLAT_OUTPUT_PATH, abstractDocumentSource.resourcePathToFilename("/foo/bar"));
-		assertEquals(FLAT_OUTPUT_PATH, abstractDocumentSource.resourcePathToFilename("/foo/bar/"));
-		assertEquals(FLAT_OUTPUT_PATH, abstractDocumentSource.resourcePathToFilename("foo/bar"));
-		assertEquals(FLAT_OUTPUT_PATH, abstractDocumentSource.resourcePathToFilename("foo/bar/"));
-		assertEquals("bar.json", abstractDocumentSource.resourcePathToFilename("bar"));
+  public static final String OUTPUT_PATH = "foo/bar";
+  public static final String FLAT_OUTPUT_PATH = "foo_bar";
 
-		abstractDocumentSource = getAbstractDocumentSource(false);
-		assertEquals(OUTPUT_PATH, abstractDocumentSource.resourcePathToFilename("/foo/bar"));
-		assertEquals(OUTPUT_PATH, abstractDocumentSource.resourcePathToFilename("/foo/bar/"));
-		assertEquals(OUTPUT_PATH, abstractDocumentSource.resourcePathToFilename("foo/bar"));
-		assertEquals(OUTPUT_PATH, abstractDocumentSource.resourcePathToFilename("foo/bar/"));
-		assertEquals("bar.json", abstractDocumentSource.resourcePathToFilename("bar"));
-	}
+  private AbstractDocumentSource getAbstractDocumentSource(final boolean useOutputFlatStructure) {
+    return new AbstractDocumentSource(new LogAdapter((Logger) null), null, null, null, null,
+        useOutputFlatStructure) {
+      @Override
+      public void loadDocuments() throws Exception, GenerateException {
 
-	@Test
-	public void testCreateFile() throws Exception {
-		AbstractDocumentSource abstractDocumentSource = getAbstractDocumentSource(true);
+      }
+    };
+  }
 
-		File target = abstractDocumentSource.createFile(new File("target"), OUTPUT_PATH);
-		assertTrue(target.getPath(), FilenameUtils.equalsNormalized("target/foo/bar.json", target.getPath()));
+  @Test
+  public void testCreateFile() throws Exception {
+    AbstractDocumentSource abstractDocumentSource = getAbstractDocumentSource(true);
 
-		target = abstractDocumentSource.createFile(new File("target"), FLAT_OUTPUT_PATH);
-		assertTrue(target.getPath(), FilenameUtils.equalsNormalized("target/foo_bar.json", target.getPath()));
-	}
+    File target = abstractDocumentSource.createFile(new File("target"), OUTPUT_PATH);
+    assertTrue(target.getPath(), FilenameUtils.equalsNormalized("target/foo/bar", target.getPath()));
 
-	private AbstractDocumentSource getAbstractDocumentSource(final boolean useOutputFlatStructure) {
-		return new AbstractDocumentSource(new LogAdapter((Logger) null), null, null, null, null, useOutputFlatStructure) {
-			@Override
-			public void loadDocuments() throws Exception, GenerateException {
+    target = abstractDocumentSource.createFile(new File("target"), FLAT_OUTPUT_PATH);
+    assertTrue(target.getPath(), FilenameUtils.equalsNormalized("target/foo_bar", target.getPath()));
+  }
 
-			}
-		};
-	}
+  @Test
+  public void testResourcePathToFilename() throws Exception {
+    AbstractDocumentSource abstractDocumentSource = getAbstractDocumentSource(true);
+    assertEquals(FLAT_OUTPUT_PATH, abstractDocumentSource.resourcePathToFilename("/foo/bar"));
+    assertEquals(FLAT_OUTPUT_PATH, abstractDocumentSource.resourcePathToFilename("/foo/bar/"));
+    assertEquals(FLAT_OUTPUT_PATH, abstractDocumentSource.resourcePathToFilename("foo/bar"));
+    assertEquals(FLAT_OUTPUT_PATH, abstractDocumentSource.resourcePathToFilename("foo/bar/"));
+    assertEquals("bar", abstractDocumentSource.resourcePathToFilename("bar"));
+
+    abstractDocumentSource = getAbstractDocumentSource(false);
+    assertEquals(OUTPUT_PATH, abstractDocumentSource.resourcePathToFilename("/foo/bar"));
+    assertEquals(OUTPUT_PATH, abstractDocumentSource.resourcePathToFilename("/foo/bar/"));
+    assertEquals(OUTPUT_PATH, abstractDocumentSource.resourcePathToFilename("foo/bar"));
+    assertEquals(OUTPUT_PATH, abstractDocumentSource.resourcePathToFilename("foo/bar/"));
+    assertEquals("bar", abstractDocumentSource.resourcePathToFilename("bar"));
+  }
 }


### PR DESCRIPTION
Tests have been updated again, and the generated strapdown.html has been verified too.

The only modification has been to remove the '.json' extension from the method resourcePathToFilename of the class AbstractDocumentSource and updating the tests.

The result is a service.json file, and the individual service specs without the .json extension.
