### PR TITLE
Update MustacheItem.java

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/mustache/MustacheItem.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mustache/MustacheItem.java
@@ -26,7 +26,7 @@ public class MustacheItem {
         this.linkType = this.type;
         this.description = Utils.getStrInOption(documentationSchema.description());
         this.required = documentationSchema.required();
-        this.notes = Utils.getStrInOption(documentationSchema.description());
+        this.notes = Utils.getStrInOption(documentationSchema.notes());
         this.linkType = TypeUtils.filterBasicTypes(this.linkType);
     }
 


### PR DESCRIPTION
read notes from the proper location (notes, instead of description) Fixes part of issue https://github.com/kongchen/swagger-maven-plugin/issues/42. (that notes and description were the same value)
