### PR TITLE
Added inclusion of missing access attributes for model properties.

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/mustache/MustacheItem.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mustache/MustacheItem.java
@@ -28,6 +28,7 @@ public class MustacheItem {
         this.linkType = this.type;
         this.description = Utils.getStrInOption(documentationSchema.description());
         this.required = documentationSchema.required();
+        this.access = Utils.getStrInOption(documentationSchema.access());
         this.notes = Utils.getStrInOption(documentationSchema.description());
         this.linkType = TypeUtils.filterBasicTypes(this.linkType);
         this.allowableValue = Utils.allowableValuesToString(documentationSchema.allowableValues());


### PR DESCRIPTION
Changed the Mustache item constructor so that it also takes `access` into account. This fix should work once swagger-core's Issue https://github.com/wordnik/swagger-core/issues/508 gets fixed. I also made a pull request for that. 

I can confirm both pull-requests work in my environment, and my swagger api description now includes `notes` and `access` information.
