### PR TITLE
Resolve compile classpath elements instead of runtime elements.

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiDocumentMojo.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiDocumentMojo.java
@@ -19,7 +19,7 @@ import java.util.List;
  * @goal generate
  * @phase compile
  * @configurator include-project-dependencies
- * @requiresDependencyResolution runtime
+ * @requiresDependencyResolution compile+runtime
  */
 public class ApiDocumentMojo extends AbstractMojo {
 

--- a/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/IncludeProjectDependenciesComponentConfigurator.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/IncludeProjectDependenciesComponentConfigurator.java
@@ -46,16 +46,16 @@ public class IncludeProjectDependenciesComponentConfigurator extends AbstractCom
     }
 
     private void addProjectDependenciesToClassRealm(ExpressionEvaluator expressionEvaluator, ClassRealm containerRealm) throws ComponentConfigurationException {
-        List<String> runtimeClasspathElements;
+        List<String> compileClasspathElements;
         try {
             //noinspection unchecked
-            runtimeClasspathElements = (List<String>) expressionEvaluator.evaluate("${project.runtimeClasspathElements}");
+            compileClasspathElements = (List<String>) expressionEvaluator.evaluate("${project.compileClasspathElements}");
         } catch (ExpressionEvaluationException e) {
-            throw new ComponentConfigurationException("There was a problem evaluating: ${project.runtimeClasspathElements}", e);
+            throw new ComponentConfigurationException("There was a problem evaluating: ${project.compileClasspathElements}", e);
         }
 
         // Add the project dependencies to the ClassRealm
-        final URL[] urls = buildURLs(runtimeClasspathElements);
+        final URL[] urls = buildURLs(compileClasspathElements);
         for (URL url : urls) {
             containerRealm.addConstituent(url);
         }


### PR DESCRIPTION
We ran into an issue with classes not found by the swagger-maven-plugin which were set to scope "provided". Removing the "provided" fixed it but caused issues with our JBoss instance. This small patch fixed it.
