### PR TITLE
OutputTemplate - apiDocuments consistent order

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/mustache/OutputTemplate.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mustache/OutputTemplate.java
@@ -186,6 +186,7 @@ public class OutputTemplate {
             // different indexs, no special handling required
             return;
         }
+        Collections.sort(apiDocuments);
         int i = 0;
         for (MustacheDocument apiDocument : apiDocuments) {
             apiDocument.setIndex(i); // requires delete of final modifier


### PR DESCRIPTION
In current implementation there is no consistent order of apiDocument within mustache templates. This change introduces sorting by request path if apiDocuments have no indexes defined.
