### PR TITLE
Added possibility to override the ApiReader class

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ If you cannot wait to try out the plugin, here's a [sample project](https://gith
         </apiInfo>
         <overridingModels>/swagger-overriding-models.json</overridingModels>
         <swaggerInternalFilter>com.wordnik.swagger.config.DefaultSpecFilter</swaggerInternalFilter>
+        <swaggerApiReader>com.wordnik.swagger.jaxrs.reader.DefaultJaxrsApiReader</swaggerApiReader>
         <!---General parameters END-->
 
         <!---Document generation parameters BEGIN-->
@@ -176,6 +177,7 @@ One ```apiSource``` can be considered as a set of APIs for one ```apiVersion``` 
 | `apiInfo` | Some information of the API document. |
 | `overridingModels` | The name of *overridingModels* file, see more details in sections below. |
 | `swaggerInternalFilter` | If not null, the value should be full name of class implementing `com.wordnik.swagger.core.filter.SpecFilter`. This allows you to filter both methods and parameters from generated api. |
+| `swaggerApiReader` | If not null, the value should be full name of class implementing `com.wordnik.swagger.reader.ClassReader`. This allows you flexibly implement/override the reader's implementation. Default is `com.wordnik.swagger.jaxrs.reader.DefaultJaxrsApiReader` |
 
 
 The parameters of `apiInfo`:

--- a/src/main/java/com/github/kongchen/swagger/docgen/GenerateException.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/GenerateException.java
@@ -6,7 +6,7 @@ package com.github.kongchen.swagger.docgen;
  * @author: chekong
  * 05/29/2013
  */
-public class GenerateException extends Throwable {
+public class GenerateException extends Exception {
 
 	private static final long serialVersionUID = -1641016437077276797L;
 

--- a/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiSource.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiSource.java
@@ -70,6 +70,9 @@ public class ApiSource {
     @Parameter
     private String swaggerInternalFilter;
 
+	@Parameter
+	private String swaggerApiReader;
+
     public Set<Class> getValidClasses() throws GenerateException {
         Set<Class> classes = new HashSet<Class>();
         if (getLocations() == null) {
@@ -190,4 +193,13 @@ public class ApiSource {
     public void setSwaggerInternalFilter(String swaggerInternalFilter) {
         this.swaggerInternalFilter = swaggerInternalFilter;
     }
+
+	public String getSwaggerApiReader() {
+		return swaggerApiReader;
+	}
+
+	public void setSwaggerApiReader(String swaggerApiReader) {
+		this.swaggerApiReader = swaggerApiReader;
+	}
+    
 }

--- a/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/MavenDocumentSource.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/MavenDocumentSource.java
@@ -13,6 +13,7 @@ import com.wordnik.swagger.core.filter.SwaggerSpecFilter;
 import com.wordnik.swagger.jaxrs.JaxrsApiReader;
 import com.wordnik.swagger.jaxrs.reader.DefaultJaxrsApiReader;
 import com.wordnik.swagger.model.*;
+import com.wordnik.swagger.reader.ClassReader;
 
 import org.apache.maven.plugin.logging.Log;
 
@@ -109,7 +110,7 @@ public class MavenDocumentSource extends AbstractDocumentSource {
         Api resource = (Api) c.getAnnotation(Api.class);
 
         if (resource == null) return null;
-        JaxrsApiReader reader = new DefaultJaxrsApiReader();
+        ClassReader reader = getApiReader();
         Option<ApiListing> apiListing = reader.read(basePath, c, swaggerConfig);
 
         if (None.canEqual(apiListing)) return null;
@@ -119,4 +120,15 @@ public class MavenDocumentSource extends AbstractDocumentSource {
                                  Map$.MODULE$.<String, String>empty(),
                                  Map$.MODULE$.<String, scala.collection.immutable.List<String>>empty());
     }
+
+	private ClassReader getApiReader() throws Exception {
+		if (apiSource.getSwaggerApiReader() == null) return new DefaultJaxrsApiReader();
+		try {
+			LOG.info("Reading api reader configuration: " + apiSource.getSwaggerApiReader());
+			return (ClassReader) Class.forName(apiSource.getSwaggerApiReader()).newInstance();
+		} catch (Exception e) {
+			throw new GenerateException("Cannot load swagger api reader: "
+					+ apiSource.getSwaggerApiReader(), e);
+		}
+	}
 }

--- a/src/test/java/com/github/kongchen/swagger/docgen/TestSwaggerApiReader.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/TestSwaggerApiReader.java
@@ -1,0 +1,37 @@
+package com.github.kongchen.swagger.docgen;
+
+import java.lang.reflect.Method;
+
+import scala.collection.immutable.List;
+import scala.collection.mutable.ListBuffer;
+
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.jaxrs.reader.DefaultJaxrsApiReader;
+import com.wordnik.swagger.model.Operation;
+import com.wordnik.swagger.model.Parameter;
+import com.wordnik.swagger.model.ResponseMessage;
+
+public class TestSwaggerApiReader extends DefaultJaxrsApiReader {
+
+	@Override
+	public Operation parseOperation(Method method, ApiOperation apiOperation,
+			List<ResponseMessage> apiResponses, String isDeprecated,
+			List<Parameter> parentParams, ListBuffer<Method> parentMethods) {
+		Operation operation = super.parseOperation(method, apiOperation, apiResponses, isDeprecated,
+						parentParams, parentMethods);
+		return new Operation(operation.method(),
+				// for a testing purposes
+				"summary by the test swagger test filter",
+				operation.notes(),
+				operation.responseClass(),
+				operation.nickname(),
+				operation.position(),
+				operation.produces(),
+				operation.consumes(),
+				operation.protocols(),
+				operation.authorizations(),
+				operation.parameters(),
+				operation.responseMessages(),
+				operation.deprecated());
+	}
+}


### PR DESCRIPTION
This is required when ones need to provide any of the defaults for the project in api reader overrided class.
