### PR TITLE
Support JSR-311 @Produces and @Consumes annotations

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/mustache/MustacheContentType.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mustache/MustacheContentType.java
@@ -1,0 +1,17 @@
+package com.github.kongchen.swagger.docgen.mustache;
+
+public class MustacheContentType {
+    private String contentType;
+
+    public MustacheContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+}

--- a/src/main/java/com/github/kongchen/swagger/docgen/mustache/MustacheDocument.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mustache/MustacheDocument.java
@@ -36,6 +36,10 @@ public class MustacheDocument implements Comparable<MustacheDocument> {
 
     private List<MustacheApi> apis = new ArrayList<MustacheApi>();
 
+    private List<MustacheContentType> responseContentTypes = new ArrayList<MustacheContentType>();
+
+    private List<MustacheContentType> parameterContentTypes = new ArrayList<MustacheContentType>();
+
     @JsonIgnore
     private Set<String> requestTypes = new LinkedHashSet<String>();
 
@@ -66,6 +70,8 @@ public class MustacheDocument implements Comparable<MustacheDocument> {
         this.resourcePath = apiListing.resourcePath();
         this.index = apiListing.position();
         this.apis = new ArrayList<MustacheApi>(apiListing.apis().size());
+        this.responseContentTypes = new ArrayList<MustacheContentType>(apiListing.produces().size());
+        this.parameterContentTypes = new ArrayList<MustacheContentType>(apiListing.consumes().size());
     }
 
     public void setResourcePath(String resourcePath) {
@@ -100,6 +106,14 @@ public class MustacheDocument implements Comparable<MustacheDocument> {
         return index;
     }
 
+    public List<MustacheContentType> getResponseContentTypes() {
+        return responseContentTypes;
+    }
+
+    public List<MustacheContentType> getParameterContentTypes() {
+        return parameterContentTypes;
+    }
+    
     public void setIndex(int index) {
         this.index = index;
     }
@@ -122,6 +136,14 @@ public class MustacheDocument implements Comparable<MustacheDocument> {
             responseTypes.add(newName);
         }
 
+    }
+
+    public void addResponseContentTypes(MustacheContentType responseContentTypes) {
+        this.responseContentTypes.add(responseContentTypes);
+    }
+
+    public void addParameterContentTypes(MustacheContentType parameterContentTypes) {
+        this.parameterContentTypes.add(parameterContentTypes);
     }
 
     public List<MustacheParameterSet> analyzeParameters(List<Parameter> parameters) {

--- a/src/main/java/com/github/kongchen/swagger/docgen/mustache/MustacheOperation.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mustache/MustacheOperation.java
@@ -33,6 +33,10 @@ public class MustacheOperation {
 
     private List<MustacheParameterSet> parameters;
 
+    private final List<MustacheContentType> responseContentTypes = new ArrayList<MustacheContentType>();
+
+    private final List<MustacheContentType> parameterContentTypes = new ArrayList<MustacheContentType>();
+
     private MustacheParameterSet requestQuery;
     private MustacheParameterSet requestHeader;
     private MustacheParameterSet requestBody;
@@ -89,6 +93,16 @@ public class MustacheOperation {
             } else if (para.getParamType().equals(DocTemplateConstants.TYPE_RESPONSE_HEADER)) {
                 this.responseHeader = para;
             }
+        }
+
+        List<String> produces = JavaConversions.asJavaList(op.produces());
+        for (String produce : produces) {
+            this.responseContentTypes.add(new MustacheContentType(produce));
+        }
+
+        List<String> consumes = JavaConversions.asJavaList(op.consumes());
+        for (String consume : consumes) {
+            this.parameterContentTypes.add(new MustacheContentType(consume));
         }
     }
 
@@ -190,4 +204,13 @@ public class MustacheOperation {
     public List<MustacheResponseClass> getResponseClasses() {
         return responseClasses;
     }
+
+    public List<MustacheContentType> getResponseContentTypes() {
+        return responseContentTypes;
+    }
+
+    public List<MustacheContentType> getParameterContentTypes() {
+        return parameterContentTypes;
+    }
+
 }

--- a/src/main/java/com/github/kongchen/swagger/docgen/mustache/OutputTemplate.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mustache/OutputTemplate.java
@@ -2,6 +2,8 @@ package com.github.kongchen.swagger.docgen.mustache;
 
 import java.util.*;
 
+import scala.collection.JavaConversions;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsonschema.JsonSchema;
 import com.github.kongchen.swagger.docgen.AbstractDocumentSource;
@@ -139,6 +141,16 @@ public class OutputTemplate {
             addDateType(mustacheDocument, dataType);
         }
         filterDatatypes(dataTypes);
+
+        List<String> produces = JavaConversions.asJavaList(swaggerDoc.produces());
+        for (String produce : produces) {
+            mustacheDocument.addResponseContentTypes(new MustacheContentType(produce));
+        }
+
+        List<String> consumes = JavaConversions.asJavaList(swaggerDoc.consumes());
+        for (String consume : consumes) {
+            mustacheDocument.addParameterContentTypes(new MustacheContentType(consume));
+        }
 
         return mustacheDocument;
     }


### PR DESCRIPTION
This patch allows us to generate the JSR-311 @Produces and @Consumes annotations. 
