### PR TITLE
Rename errorResponses to responseMessages to better match swagger json.

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/mustache/MustacheOperation.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mustache/MustacheOperation.java
@@ -45,7 +45,7 @@ public class MustacheOperation {
 
     private static final Pattern genericInNotes = Pattern.compile("(/\\*.*<)((\\w+|((\\w+\\.)+\\w+))|(((\\w+|((\\w+\\.)+\\w+)),)+(\\w+|((\\w+\\.)+\\w+))))(>.*\\*/)");
 
-    private List<MustacheResponseMessage> errorResponses = new ArrayList<MustacheResponseMessage>();
+    private List<MustacheResponseMessage> responseMessages = new ArrayList<MustacheResponseMessage>();
 
     List<MustacheSample> samples;
 
@@ -75,7 +75,7 @@ public class MustacheOperation {
                     String className = responseMessage.responseModel().get();
                     this.responseClasses.add(new MustacheResponseClass(className));
                 }
-                this.errorResponses.add(new MustacheResponseMessage(responseMessage));
+                this.responseMessages.add(new MustacheResponseMessage(responseMessage));
             }
         }
         if (parameters == null) {
@@ -193,8 +193,16 @@ public class MustacheOperation {
         return parameters;
     }
 
+    public List<MustacheResponseMessage> getResponseMessages() {
+        return responseMessages;
+    }
+
+    /**
+     * @deprecated Use {@link #getResponseMessages} instead
+     */
+    @Deprecated
     public List<MustacheResponseMessage> getErrorResponses() {
-        return errorResponses;
+        return responseMessages;
     }
 
     public MustacheResponseClass getResponseClass() {

--- a/src/test/java/com/github/kongchen/swagger/docgen/mavenplugin/MavenDocumentSourceTest.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/mavenplugin/MavenDocumentSourceTest.java
@@ -95,6 +95,11 @@ public class MavenDocumentSourceTest {
                                     op.getRequestHeader().getParas().get(0).getType());
                             Assert.assertEquals("application/json, application/*",
                                     op.getRequestHeader().getParas().get(0).getAllowableValue());
+                            Assert.assertEquals(op.getResponseMessages().size(), 2);
+                            Assert.assertEquals(op.getResponseMessages().get(0).getMessage(), "Invalid ID supplied");
+                            Assert.assertEquals(op.getResponseMessages().get(0).getCode(), 400);
+                            Assert.assertEquals(op.getResponseMessages().get(1).getCode(), 404);
+                            // Testing deprecated method. Should remove tests when deprecated method is gone
                             Assert.assertEquals(op.getErrorResponses().size(), 2);
                             Assert.assertEquals(op.getErrorResponses().get(0).getMessage(), "Invalid ID supplied");
                             Assert.assertEquals(op.getErrorResponses().get(0).getCode(), 400);
@@ -163,6 +168,11 @@ public class MavenDocumentSourceTest {
 
 							Assert.assertEquals(0, op.getParameters().size());
 
+							Assert.assertEquals(op.getResponseMessages().size(), 2);
+							Assert.assertEquals(op.getResponseMessages().get(0).getMessage(), "Invalid ID supplied");
+							Assert.assertEquals(op.getResponseMessages().get(0).getCode(), 400);
+							Assert.assertEquals(op.getResponseMessages().get(1).getCode(), 404);
+							// Testing deprecated method. Should remove tests when deprecated method is gone
 							Assert.assertEquals(op.getErrorResponses().size(), 2);
 							Assert.assertEquals(op.getErrorResponses().get(0).getMessage(), "Invalid ID supplied");
 							Assert.assertEquals(op.getErrorResponses().get(0).getCode(), 400);


### PR DESCRIPTION
Swagger response messages can be used for success and error codes. The previous name only implied the latter usage.

To make existing templates work, still leave getErrorResponses around, but deprecate it.
