### PR TITLE
fix exception when securityDefinitions are missing from pom

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/MavenDocumentSource.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/MavenDocumentSource.java
@@ -53,13 +53,13 @@ public class MavenDocumentSource extends AbstractDocumentSource {
                     swagger.addSecurityDefinition(entry.getKey(), entry.getValue());
                 }
             }
-        }
 
-        // sort security defs to make output consistent
-        Map<String, SecuritySchemeDefinition> defs = swagger.getSecurityDefinitions();
-        Map<String, SecuritySchemeDefinition> sortedDefs = new TreeMap<String, SecuritySchemeDefinition>();
-        sortedDefs.putAll(defs);
-        swagger.setSecurityDefinitions(sortedDefs);
+            // sort security defs to make output consistent
+            Map<String, SecuritySchemeDefinition> defs = swagger.getSecurityDefinitions();
+            Map<String, SecuritySchemeDefinition> sortedDefs = new TreeMap<String, SecuritySchemeDefinition>();
+            sortedDefs.putAll(defs);
+            swagger.setSecurityDefinitions(sortedDefs);
+        }
 
         if (FilterFactory.getFilter() != null) {
             swagger = new SpecFilter().filter(swagger, FilterFactory.getFilter(),


### PR DESCRIPTION
An omitted securityDefinitions tag in apiSource causes an exception:

```
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal com.github.kongchen:swagger-maven-plugin:3.0.1-SNAPSHOT:generate (default) on project foo: null
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:217)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
	at org.apache.maven.lifecycle.internal.MojoExecutor.executeForkedExecutions(MojoExecutor.java:365)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:199)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:84)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:59)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.singleThreadedBuild(LifecycleStarter.java:183)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:161)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:320)
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:156)
	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:537)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:196)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:141)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:290)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:230)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:409)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:352)
	at org.codehaus.classworlds.Launcher.main(Launcher.java:47)
Caused by: org.apache.maven.plugin.MojoExecutionException
	at com.github.kongchen.swagger.docgen.mavenplugin.ApiDocumentMojo.execute(ApiDocumentMojo.java:91)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:101)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:209)
	... 24 more
Caused by: java.lang.NullPointerException
	at java.util.TreeMap.putAll(TreeMap.java:313)
	at com.github.kongchen.swagger.docgen.mavenplugin.MavenDocumentSource.loadDocuments(MavenDocumentSource.java:61)
	at com.github.kongchen.swagger.docgen.mavenplugin.ApiDocumentMojo.execute(ApiDocumentMojo.java:69)
	... 26 more
```