### PR TITLE
Re-adding @RequestBody to whitelist after it was accidentally removed

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
@@ -340,6 +340,7 @@ public abstract class AbstractReader {
         validParameterAnnotations.add(HeaderParam.class);
         validParameterAnnotations.add(FormParam.class);
         validParameterAnnotations.add(RequestParam.class);
+        validParameterAnnotations.add(RequestBody.class);
         validParameterAnnotations.add(PathVariable.class);
 
 


### PR DESCRIPTION
It looks like I accidentally removed RequestBody from the annotation whitelist when I went back to add the PathVariable annotation. I restored it in this PR.

From: https://github.com/kongchen/swagger-maven-plugin/issues/192