### PR TITLE
Support for custom ModelConverters

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ You can specify several `apiSource`s. Generally, one is enough.
 | `apiModelPropertyAccessExclusions` | Allows the exclusion of specified `@ApiModelProperty` fields. This can be used to hide certain model properties from the swagger spec. More details [below](#apiModelPropertyAccessExclusions)|
 | `jsonExampleValues` | If `true`, all example values in `@ApiModelProperty` will be handled as json raw values. This is useful for creating valid examples in the generated json for all property types, including non-string ones. |
 | `skipSwaggerGeneration` | If `true`, swagger generation will be skipped. Default is `false`. |
+| `modelConverters` | List of custom implementations of `io.swagger.converter.ModelConverter` that should be used when generating the swagger files. | 
 
 # <a id="templatefile">Template File</a>
 
@@ -287,6 +288,7 @@ There's a [sample here](https://github.com/swagger-maven-plugin/swagger-maven-ex
                 <swaggerDirectory>${basedir}/generated/swagger-ui</swaggerDirectory>
                 <swaggerApiReader>com.wordnik.swagger.jaxrs.reader.DefaultJaxrsApiReader</swaggerApiReader>
                 <attachSwaggerArtifact>true</attachSwaggerArtifact>
+                <modelConverters>io.swagger.validator.BeanValidator</modelConverters>
             </apiSource>
         </apiSources>
     </configuration>
@@ -298,6 +300,15 @@ There's a [sample here](https://github.com/swagger-maven-plugin/swagger-maven-ex
             </goals>
         </execution>
     </executions>
+    <dependencies>
+        <!-- Adding dependency to swagger-hibernate-validations to enable the BeanValidator as a custom
+             model converter -->
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-hibernate-validations</artifactId>
+            <version>1.5.6</version>
+        </dependency>
+    </dependencies>
 </plugin>
 ...
 </plugins>

--- a/src/main/java/com/github/kongchen/swagger/docgen/AbstractDocumentSource.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/AbstractDocumentSource.java
@@ -280,7 +280,7 @@ public abstract class AbstractDocumentSource {
     }
 
     protected File createFile(File dir, String outputResourcePath)
-       throws IOException {
+            throws IOException {
         File serviceFile;
         int i = outputResourcePath.lastIndexOf("/");
         if (i != -1) {
@@ -314,7 +314,7 @@ public abstract class AbstractDocumentSource {
             throw new GenerateException(e);
         }
         OutputStreamWriter writer = new OutputStreamWriter(fileOutputStream,
-           Charset.forName("UTF-8"));
+                Charset.forName("UTF-8"));
 
         try {
             TemplatePath tp = Utils.parseTemplateUrl(templatePath);

--- a/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiDocumentMojo.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiDocumentMojo.java
@@ -23,7 +23,7 @@ import com.github.kongchen.swagger.docgen.GenerateException;
  * Date: 3/7/13
  */
 @Mojo( name = "generate", defaultPhase = LifecyclePhase.COMPILE, configurator = "include-project-dependencies",
-   requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
+       requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class ApiDocumentMojo extends AbstractMojo {
 
     /**
@@ -67,12 +67,12 @@ public class ApiDocumentMojo extends AbstractMojo {
         }
         if (useSwaggerSpec11()) {
             throw new MojoExecutionException("You may use an old version of swagger which is not supported by swagger-maven-plugin 2.0+\n" +
-               "swagger-maven-plugin 2.0+ only supports swagger-core 1.3.x");
+                "swagger-maven-plugin 2.0+ only supports swagger-core 1.3.x");
         }
 
         if (useSwaggerSpec13()) {
             throw new MojoExecutionException("You may use an old version of swagger which is not supported by swagger-maven-plugin 3.0+\n" +
-               "swagger-maven-plugin 3.0+ only supports swagger spec 2.0");
+                    "swagger-maven-plugin 3.0+ only supports swagger spec 2.0");
         }
 
         try {

--- a/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiDocumentMojo.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiDocumentMojo.java
@@ -23,7 +23,7 @@ import com.github.kongchen.swagger.docgen.GenerateException;
  * Date: 3/7/13
  */
 @Mojo( name = "generate", defaultPhase = LifecyclePhase.COMPILE, configurator = "include-project-dependencies",
-       requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
+   requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class ApiDocumentMojo extends AbstractMojo {
 
     /**
@@ -40,7 +40,7 @@ public class ApiDocumentMojo extends AbstractMojo {
 
     @Component
     private MavenProjectHelper projectHelper;
-    
+
     /**
      * A flag indicating if the generation should be skipped.
      */
@@ -61,18 +61,18 @@ public class ApiDocumentMojo extends AbstractMojo {
             getLog().info("Swagger generation is skipped.");
             return;
         }
-        
+
         if (apiSources == null) {
             throw new MojoFailureException("You must configure at least one apiSources element");
         }
         if (useSwaggerSpec11()) {
             throw new MojoExecutionException("You may use an old version of swagger which is not supported by swagger-maven-plugin 2.0+\n" +
-                "swagger-maven-plugin 2.0+ only supports swagger-core 1.3.x");
+               "swagger-maven-plugin 2.0+ only supports swagger-core 1.3.x");
         }
 
         if (useSwaggerSpec13()) {
             throw new MojoExecutionException("You may use an old version of swagger which is not supported by swagger-maven-plugin 3.0+\n" +
-                    "swagger-maven-plugin 3.0+ only supports swagger spec 2.0");
+               "swagger-maven-plugin 3.0+ only supports swagger spec 2.0");
         }
 
         try {
@@ -84,31 +84,32 @@ public class ApiDocumentMojo extends AbstractMojo {
                 AbstractDocumentSource documentSource;
 
                 if(apiSource.isSpringmvc()){
-                	documentSource = new SpringMavenDocumentSource(apiSource, getLog());
+                    documentSource = new SpringMavenDocumentSource(apiSource, getLog());
                 }else{
-                	documentSource = new MavenDocumentSource(apiSource, getLog());
+                    documentSource = new MavenDocumentSource(apiSource, getLog());
                 }
 
                 documentSource.loadTypesToSkip();
                 documentSource.loadModelModifier();
+                documentSource.loadModelConverters();
                 documentSource.loadDocuments();
-				if (apiSource.getOutputPath() != null){
-					File outputDirectory = new File(apiSource.getOutputPath()).getParentFile();
-					if (outputDirectory != null && !outputDirectory.exists()) {
-						if (!outputDirectory.mkdirs()) {
-							throw new MojoExecutionException("Create directory[" +
-									apiSource.getOutputPath() + "] for output failed.");
-						}
-					}
-				}
-				if (apiSource.getTemplatePath()!=null) {
-					documentSource.toDocuments();
-				}
+                if (apiSource.getOutputPath() != null){
+                    File outputDirectory = new File(apiSource.getOutputPath()).getParentFile();
+                    if (outputDirectory != null && !outputDirectory.exists()) {
+                        if (!outputDirectory.mkdirs()) {
+                            throw new MojoExecutionException("Create directory[" +
+                               apiSource.getOutputPath() + "] for output failed.");
+                        }
+                    }
+                }
+                if (apiSource.getTemplatePath()!=null) {
+                    documentSource.toDocuments();
+                }
                 documentSource.toSwaggerDocuments(
-                        apiSource.getSwaggerUIDocBasePath() == null
-                                ? apiSource.getBasePath()
-                                : apiSource.getSwaggerUIDocBasePath(),
-                        apiSource.getOutputFormats());
+                   apiSource.getSwaggerUIDocBasePath() == null
+                      ? apiSource.getBasePath()
+                      : apiSource.getSwaggerUIDocBasePath(),
+                   apiSource.getOutputFormats());
 
 
                 if ( apiSource.isAttachSwaggerArtifact() && apiSource.getSwaggerDirectory() != null && this.project != null) {

--- a/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiDocumentMojo.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiDocumentMojo.java
@@ -40,7 +40,7 @@ public class ApiDocumentMojo extends AbstractMojo {
 
     @Component
     private MavenProjectHelper projectHelper;
-
+    
     /**
      * A flag indicating if the generation should be skipped.
      */
@@ -61,7 +61,7 @@ public class ApiDocumentMojo extends AbstractMojo {
             getLog().info("Swagger generation is skipped.");
             return;
         }
-
+        
         if (apiSources == null) {
             throw new MojoFailureException("You must configure at least one apiSources element");
         }
@@ -84,32 +84,32 @@ public class ApiDocumentMojo extends AbstractMojo {
                 AbstractDocumentSource documentSource;
 
                 if(apiSource.isSpringmvc()){
-                    documentSource = new SpringMavenDocumentSource(apiSource, getLog());
+                	documentSource = new SpringMavenDocumentSource(apiSource, getLog());
                 }else{
-                    documentSource = new MavenDocumentSource(apiSource, getLog());
+                	documentSource = new MavenDocumentSource(apiSource, getLog());
                 }
 
                 documentSource.loadTypesToSkip();
                 documentSource.loadModelModifier();
                 documentSource.loadModelConverters();
                 documentSource.loadDocuments();
-                if (apiSource.getOutputPath() != null){
-                    File outputDirectory = new File(apiSource.getOutputPath()).getParentFile();
-                    if (outputDirectory != null && !outputDirectory.exists()) {
-                        if (!outputDirectory.mkdirs()) {
-                            throw new MojoExecutionException("Create directory[" +
-                               apiSource.getOutputPath() + "] for output failed.");
-                        }
-                    }
-                }
-                if (apiSource.getTemplatePath()!=null) {
-                    documentSource.toDocuments();
-                }
+				if (apiSource.getOutputPath() != null){
+					File outputDirectory = new File(apiSource.getOutputPath()).getParentFile();
+					if (outputDirectory != null && !outputDirectory.exists()) {
+						if (!outputDirectory.mkdirs()) {
+							throw new MojoExecutionException("Create directory[" +
+									apiSource.getOutputPath() + "] for output failed.");
+						}
+					}
+				}
+				if (apiSource.getTemplatePath()!=null) {
+					documentSource.toDocuments();
+				}
                 documentSource.toSwaggerDocuments(
-                   apiSource.getSwaggerUIDocBasePath() == null
-                      ? apiSource.getBasePath()
-                      : apiSource.getSwaggerUIDocBasePath(),
-                   apiSource.getOutputFormats());
+                        apiSource.getSwaggerUIDocBasePath() == null
+                                ? apiSource.getBasePath()
+                                : apiSource.getSwaggerUIDocBasePath(),
+                        apiSource.getOutputFormats());
 
 
                 if ( apiSource.isAttachSwaggerArtifact() && apiSource.getSwaggerDirectory() != null && this.project != null) {

--- a/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiSource.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiSource.java
@@ -116,6 +116,9 @@ public class ApiSource {
     @Parameter
     private File descriptionFile;
 
+    @Parameter
+    private List<String> modelConverters;
+
     public Set<Class<?>> getValidClasses() throws GenerateException {
         Set<Class<?>> classes = new HashSet<Class<?>>();
         if (getLocations() == null) {
@@ -321,6 +324,14 @@ public class ApiSource {
 
     public void setDescriptionFile(File descriptionFile) {
         this.descriptionFile = descriptionFile;
+    }
+
+    public List<String> getModelConverters() {
+        return modelConverters;
+    }
+
+    public void setModelConverters(List<String> modelConverters) {
+        this.modelConverters = modelConverters;
     }
 }
 

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/ModelModifier.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/ModelModifier.java
@@ -41,7 +41,7 @@ public class ModelModifier extends ModelResolver {
             throw new GenerateException(e);
         }
     }
-
+    
     List<String> apiModelPropertyAccessExclusions = new ArrayList<String>();
 
     public List<String> getApiModelPropertyAccessExclusions() {
@@ -51,7 +51,7 @@ public class ModelModifier extends ModelResolver {
     public void setApiModelPropertyAccessExclusions(List<String> apiModelPropertyAccessExclusions) {
         this.apiModelPropertyAccessExclusions = apiModelPropertyAccessExclusions;
     }
-
+    
     @Override
     public Property resolveProperty(Type type, ModelConverterContext context, Annotation[] annotations, Iterator<ModelConverter> chain) {
         if(modelSubtitutes.containsKey(type)) {
@@ -76,37 +76,37 @@ public class ModelModifier extends ModelResolver {
     @Override
     public Model resolve(JavaType type, ModelConverterContext context, Iterator<ModelConverter> chain) {
         Model model = super.resolve(type, context, chain);
-
+        
         // If there are no @ApiModelPropety exclusions configured, return the untouched model
         if (apiModelPropertyAccessExclusions == null || apiModelPropertyAccessExclusions.isEmpty()) {
             return model;
-        }
-
+        } 
+        
         Class<?> cls = type.getRawClass();
-
+                
         for (Method method : cls.getDeclaredMethods()) {
-
+            
             ApiModelProperty apiModelPropertyAnnotation = AnnotationUtils.findAnnotation(method, ApiModelProperty.class);
-
+            
             if (false == (apiModelPropertyAnnotation instanceof ApiModelProperty)) {
                 continue;
             }
-
+            
             String apiModelPropertyAccess = apiModelPropertyAnnotation.access();
             String apiModelPropertyName = apiModelPropertyAnnotation.name();
-
+            
             // If the @ApiModelProperty is not populated with both #name and #access, skip it
             if (apiModelPropertyAccess.isEmpty() || apiModelPropertyName.isEmpty()) {
                 continue;
             }
-
+            
             // Check to see if the value of @ApiModelProperty#access is one to exclude.
             // If so, remove it from the previously-calculated model.
             if (apiModelPropertyAccessExclusions.contains(apiModelPropertyAccess)) {
                 model.getProperties().remove(apiModelPropertyName);
             }
         }
-
+        
         return model;
     }
 }

--- a/src/test/java/com/github/kongchen/smp/integration/SwaggerMavenPluginTest.java
+++ b/src/test/java/com/github/kongchen/smp/integration/SwaggerMavenPluginTest.java
@@ -61,7 +61,7 @@ public class SwaggerMavenPluginTest extends AbstractMojoTestCase {
 
     @Test
     public void testGeneratedSwaggerSpecJson() throws Exception {
-        assertGeneratedSwaggerSpecJson("This is a sample.");
+        assertGeneratedSwaggerSpecJson("This is a sample.", "/expectedOutput/swagger.json");
     }
 
     @Test
@@ -72,7 +72,7 @@ public class SwaggerMavenPluginTest extends AbstractMojoTestCase {
     @Test
     public void testSwaggerCustomReaderJson() throws Exception {
         setCustomReader(mojo, "com.wordnik.jaxrs.CustomJaxrsReader");
-        assertGeneratedSwaggerSpecJson("Processed with CustomJaxrsReader");
+        assertGeneratedSwaggerSpecJson("Processed with CustomJaxrsReader", "/expectedOutput/swagger.json");
     }
 
     @Test
@@ -214,11 +214,11 @@ public class SwaggerMavenPluginTest extends AbstractMojoTestCase {
         }
     }
 
-    private void assertGeneratedSwaggerSpecJson(String description) throws MojoExecutionException, MojoFailureException, IOException {
+    private void assertGeneratedSwaggerSpecJson(String description, String expectedOutput) throws MojoExecutionException, MojoFailureException, IOException {
         mojo.execute();
 
         JsonNode actualJson = mapper.readTree(new File(swaggerOutputDir, "swagger.json"));
-        JsonNode expectJson = mapper.readTree(this.getClass().getResourceAsStream("/expectedOutput/swagger.json"));
+        JsonNode expectJson = mapper.readTree(this.getClass().getResourceAsStream(expectedOutput));
 
         changeDescription(expectJson, description);
         assertJsonEquals(expectJson, actualJson, Configuration.empty().when(IGNORING_ARRAY_ORDER));
@@ -241,10 +241,17 @@ public class SwaggerMavenPluginTest extends AbstractMojoTestCase {
     }
 
     @Test
-    public void testCustomModelConverter() throws MojoFailureException, MojoExecutionException, IOException {
+    public void testCustomModelConverterYaml() throws MojoFailureException, MojoExecutionException, IOException {
         mojo.getApiSources().get(0).setModelConverters(ImmutableList.of(PetIdToStringModelConverter.class.getName()));
 
         assertGeneratedSwaggerSpecYaml("This is a sample.", "/expectedOutput/swagger-with-converter.yaml");
+    }
+
+    @Test
+    public void testCustomModelConverterJson() throws MojoFailureException, MojoExecutionException, IOException {
+        mojo.getApiSources().get(0).setModelConverters(ImmutableList.of(PetIdToStringModelConverter.class.getName()));
+
+        assertGeneratedSwaggerSpecJson("This is a sample.", "/expectedOutput/swagger-with-converter.json");
     }
 
 }

--- a/src/test/java/com/github/kongchen/smp/integration/utils/PetIdToStringModelConverter.java
+++ b/src/test/java/com/github/kongchen/smp/integration/utils/PetIdToStringModelConverter.java
@@ -10,6 +10,9 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Iterator;
 
+/**
+ * A ModelConverter used for testing adding custom model converters.
+ */
 public class PetIdToStringModelConverter extends AbstractModelConverter {
 
     public PetIdToStringModelConverter() {
@@ -26,7 +29,6 @@ public class PetIdToStringModelConverter extends AbstractModelConverter {
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }
-        return iterator.hasNext() ? iterator.next().resolveProperty(type, modelConverterContext, annotations, iterator) :
-                super.resolveProperty(type, modelConverterContext, annotations, iterator);
+        return super.resolveProperty(type, modelConverterContext, annotations, iterator);
     }
 }

--- a/src/test/java/com/github/kongchen/smp/integration/utils/PetIdToStringModelConverter.java
+++ b/src/test/java/com/github/kongchen/smp/integration/utils/PetIdToStringModelConverter.java
@@ -1,0 +1,32 @@
+package com.github.kongchen.smp.integration.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.converter.ModelConverter;
+import io.swagger.converter.ModelConverterContext;
+import io.swagger.jackson.AbstractModelConverter;
+import io.swagger.models.properties.Property;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Iterator;
+
+public class PetIdToStringModelConverter extends AbstractModelConverter {
+
+    public PetIdToStringModelConverter() {
+        super(new ObjectMapper());
+    }
+
+    @Override
+    public Property resolveProperty(Type type, ModelConverterContext modelConverterContext, Annotation[] annotations, Iterator<ModelConverter> iterator) {
+        try {
+            Type expectedType = _mapper.constructType(Class.forName("com.wordnik.sample.model.PetId"));
+            if (type.equals(expectedType)) {
+                return super.resolveProperty(_mapper.constructType(Class.forName("java.lang.String")), modelConverterContext, annotations, iterator);
+            }
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+        return iterator.hasNext() ? iterator.next().resolveProperty(type, modelConverterContext, annotations, iterator) :
+                super.resolveProperty(type, modelConverterContext, annotations, iterator);
+    }
+}

--- a/src/test/resources/expectedOutput/swagger-with-converter.json
+++ b/src/test/resources/expectedOutput/swagger-with-converter.json
@@ -1,0 +1,1409 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "This is a sample.",
+    "version": "v1",
+    "title": "Swagger Maven Plugin Sample",
+    "termsOfService": "http://www.github.com/kongchen/swagger-maven-plugin",
+    "contact": {
+      "name": "Kong Chen",
+      "url": "http://kongch.com",
+      "email": "kongchen@gmail.com"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "host": "www.example.com:8080",
+  "basePath": "/api",
+  "tags": [
+    {
+      "name": "pet",
+      "description": "Operations about pets"
+    },
+    {
+      "name": "store"
+    },
+    {
+      "name": "user",
+      "description": "Operations about user"
+    }
+  ],
+  "schemes": [
+    "http",
+    "https"
+  ],
+  "paths": {
+    "/": {
+      "get": {
+        "summary": "testingRootPathResource",
+        "description": "",
+        "operationId": "testingRootPathResource",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/pet": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Returns pet",
+        "description": "",
+        "operationId": "get",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Add a new pet to the store",
+        "description": "",
+        "operationId": "addPet",
+        "consumes": [
+          "application/json",
+          "application/xml"
+        ],
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Pet object that needs to be added to the store",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        ],
+        "responses": {
+          "405": {
+            "description": "Invalid input"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Update an existing pet",
+        "description": "",
+        "operationId": "updatePet",
+        "consumes": [
+          "application/json",
+          "application/xml"
+        ],
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Pet object that needs to be added to the store",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          },
+          "405": {
+            "description": "Validation exception"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/findByStatus": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Finds Pets by status",
+        "description": "Multiple status values can be provided with comma seperated strings",
+        "operationId": "findPetsByStatus",
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Status values that need to be considered for filter",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": "available",
+              "enum": [
+                "available",
+                "pending",
+                "sold"
+              ]
+            },
+            "collectionFormat": "multi"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid status value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/findByTags": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Finds Pets by tags",
+        "description": "Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing.",
+        "operationId": "findPetsByTags",
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "Tags to filter by",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid tag value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "deprecated": true
+      }
+    },
+    "/pet/pets/{petName}": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Finds Pets by name",
+        "description": "",
+        "operationId": "findPetByPetName",
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "petName",
+            "in": "path",
+            "description": "petName",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid status value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/test": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Test pet as json string in query",
+        "description": "",
+        "operationId": "test",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "pet",
+            "in": "query",
+            "description": "describe Pet in json here",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/test/apiimplicitparams/{path-test-name}": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Test apiimplicitparams",
+        "description": "",
+        "operationId": "testapiimplicitparams",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "header-test-name",
+            "in": "header",
+            "description": "header-test-value",
+            "required": true,
+            "type": "string",
+            "default": "z"
+          },
+          {
+            "name": "path-test-name",
+            "in": "path",
+            "description": "path-test-value",
+            "required": true,
+            "type": "string",
+            "default": "path-test-defaultValue"
+          },
+          {
+            "in": "body",
+            "name": "body-test-name",
+            "description": "body-test-value",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/test/extensions": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "testExtensions",
+        "description": "",
+        "operationId": "testingExtensions",
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "x-firstExtension": {
+          "extensionName2": "extensionValue2",
+          "extensionName1": "extensionValue1"
+        },
+        "x-extensionName3": "extensionValue3"
+      }
+    },
+    "/pet/test/testFormApiImplicitParams": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Test testFormApiImplicitParams",
+        "description": "",
+        "operationId": "testFormApiImplicitParams",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "form-test-name",
+            "in": "formData",
+            "description": "form-test-value",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": "form-test-defaultValue"
+            },
+            "collectionFormat": "multi"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/test/testingBasicAuth": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "testingBasicAuth",
+        "description": "",
+        "operationId": "testingBasicAuth",
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          },
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/{petId}": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Find pet by ID",
+        "description": "Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions",
+        "operationId": "getPetById",
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet that needs to be fetched",
+            "required": true,
+            "type": "integer",
+            "maximum": 5.0,
+            "minimum": 1.0,
+            "pattern": " [0-9]",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          },
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Updates a pet in the store with form data",
+        "description": "",
+        "operationId": "updatePetWithForm",
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet that needs to be updated",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "formData",
+            "description": "Updated name of the pet",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "status",
+            "in": "formData",
+            "description": "Updated status of the pet",
+            "required": false,
+            "type": "string",
+            "enum":["value1","value2"]
+          },
+          {
+            "name": "myHeader",
+            "in": "header",
+            "required": false,
+            "type": "string",
+            "default": ""
+          },
+          {
+            "name": "intValue",
+            "in": "header",
+            "required": false,
+            "type": "integer",
+            "default": "",
+            "format": "int32"
+          },
+          {
+            "name": "myParentHeader",
+            "in": "header",
+            "description": "Header from parent",
+            "required": false,
+            "type": "string",
+            "default": ""
+          },
+          {
+            "name": "myHeaderOnMethod",
+            "in": "header",
+            "description": "Header annotated on method",
+            "required": false,
+            "type": "string",
+            "default": ""
+          },
+          {
+            "name": "myLongHeaderOnMethod",
+            "in": "header",
+            "description": "Long header annotated on method",
+            "required": false,
+            "type": "integer",
+            "default": "",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "405": {
+            "description": "Invalid input"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Deletes a pet",
+        "description": "",
+        "operationId": "removePet",
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "api_key",
+            "in": "header",
+            "required": false,
+            "type": "string",
+            "default": ""
+          },
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "Pet id to delete",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid pet value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/{petId}/testInjectParam": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Updates a pet in the store with form data",
+        "description": "",
+        "operationId": "updatePetWithFormViaInjectParam",
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet that needs to be updated",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "formData",
+            "description": "Updated name of the pet",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "status",
+            "in": "formData",
+            "description": "Updated status of the pet",
+            "required": false,
+            "type": "string",
+            "enum":["value1","value2"]
+          },
+          {
+            "name": "myHeader",
+            "in": "header",
+            "required": false,
+            "type": "string",
+            "default": ""
+          },
+          {
+            "name": "intValue",
+            "in": "header",
+            "required": false,
+            "type": "integer",
+            "default": "",
+            "format": "int32"
+          },
+          {
+            "name": "myParentHeader",
+            "in": "header",
+            "description": "Header from parent",
+            "required": false,
+            "type": "string",
+            "default": ""
+          },
+          {
+            "name": "myHeaderOnMethod",
+            "in": "header",
+            "description": "Header annotated on method",
+            "required": false,
+            "type": "string",
+            "default": ""
+          },
+          {
+            "name": "myLongHeaderOnMethod",
+            "in": "header",
+            "description": "Long header annotated on method",
+            "required": false,
+            "type": "integer",
+            "default": "",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "405": {
+            "description": "Invalid input"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/store/order": {
+      "post": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Place an order for a pet",
+        "description": "",
+        "operationId": "placeOrder",
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "order placed for purchasing the pet",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          },
+          "400": {
+            "description": "Invalid Order"
+          }
+        }
+      }
+    },
+    "/store/order/{orderId}": {
+      "get": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Find purchase order by ID",
+        "description": "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions",
+        "operationId": "getOrderById",
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of pet that needs to be fetched",
+            "required": true,
+            "type": "string",
+            "maximum": 5.0,
+            "minimum": 1.0
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Delete purchase order by ID",
+        "description": "For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors",
+        "operationId": "deleteOrder",
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of the order that needs to be deleted",
+            "required": true,
+            "type": "string",
+            "minimum": 1.0
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      }
+    },
+    "/store/pingGet": {
+      "get": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Simple ping endpoint",
+        "description": "",
+        "operationId": "pingGet",
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful request - see response for 'pong'",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/store/pingPost": {
+      "post": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Simple ping endpoint",
+        "description": "",
+        "operationId": "pingPost",
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful request - see response for 'pong'",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/store/pingPut": {
+      "put": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Simple ping endpoint",
+        "description": "",
+        "operationId": "pingPut",
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful request - see response for 'pong'",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/user": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Create user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "createUser",
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Created user object",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
+    "/user/createWithArray": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Creates list of users with given input array",
+        "description": "",
+        "operationId": "createUsersWithArrayInput",
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "List of user object",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/User"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
+    "/user/createWithList": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Creates list of users with given input array",
+        "description": "",
+        "operationId": "createUsersWithListInput",
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "List of user object",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/User"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
+    "/user/login": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Logs user into the system",
+        "description": "",
+        "operationId": "loginUser",
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "query",
+            "description": "The user name for login",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "password",
+            "in": "query",
+            "description": "The password for login in clear text",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "400": {
+            "description": "Invalid username/password supplied"
+          }
+        }
+      }
+    },
+    "/user/logout": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Logs out current logged in user session",
+        "description": "",
+        "operationId": "logoutUser",
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
+    "/user/{username}": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Get user by user name",
+        "description": "",
+        "operationId": "getUserByName",
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be fetched. Use user1 for testing. ",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          },
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Updated user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "updateUser",
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "name that need to be deleted",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Updated user object",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid user supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Delete user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "deleteUser",
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be deleted",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      }
+    }
+  },
+  "securityDefinitions": {
+    "api_key": {
+      "type": "apiKey",
+      "name": "api_key",
+      "in": "header"
+    },
+    "basicAuth": {
+      "type": "basic"
+    },
+    "petstore_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "http://swagger.io/api/oauth/dialog",
+      "flow": "implicit",
+      "scopes": {
+        "write:pets": "modify pets in your account",
+        "read:pets": "read your pets"
+      }
+    }
+  },
+  "definitions": {
+    "Category": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "xml": {
+        "name": "Category"
+      }
+    },
+    "Order": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "petId": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "quantity": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "shipDate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "status": {
+          "type": "string",
+          "description": "Order Status",
+          "enum": [
+            "placed",
+            "approved",
+            "delivered"
+          ]
+        },
+        "complete": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "xml": {
+        "name": "Order"
+      }
+    },
+    "Pet": {
+      "type": "object",
+      "required": [
+        "name",
+        "photoUrls"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "category": {
+          "$ref": "#/definitions/Category"
+        },
+        "name": {
+          "type": "string",
+          "example": "doggie"
+        },
+        "photoUrls": {
+          "type": "array",
+          "xml": {
+            "name": "photoUrl",
+            "wrapped": true
+          },
+          "items": {
+            "type": "string"
+          }
+        },
+        "tags": {
+          "type": "array",
+          "xml": {
+            "name": "tag",
+            "wrapped": true
+          },
+          "items": {
+            "$ref": "#/definitions/Tag"
+          }
+        },
+        "status": {
+          "type": "string",
+          "description": "pet status in the store",
+          "enum": [
+            "available",
+            "pending",
+            "sold"
+          ]
+        }
+      },
+      "xml": {
+        "name": "Pet"
+      }
+    },
+    "Tag": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "xml": {
+        "name": "Tag"
+      }
+    },
+    "User": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "username": {
+          "type": "string"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "phone": {
+          "type": "string"
+        },
+        "userStatus": {
+          "type": "integer",
+          "format": "int32",
+          "example": "2",
+          "description": "User Status"
+        }
+      },
+      "xml": {
+        "name": "User"
+      }
+    }
+  }
+}

--- a/src/test/resources/expectedOutput/swagger-with-converter.yaml
+++ b/src/test/resources/expectedOutput/swagger-with-converter.yaml
@@ -1,0 +1,964 @@
+swagger: "2.0"
+info:
+  description: "This is a sample."
+  version: "v1"
+  title: "Swagger Maven Plugin Sample"
+  termsOfService: "http://www.github.com/kongchen/swagger-maven-plugin"
+  contact:
+    name: "Kong Chen"
+    url: "http://kongch.com"
+    email: "kongchen@gmail.com"
+  license:
+    name: "Apache 2.0"
+    url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+host: "www.example.com:8080"
+basePath: "/api"
+tags:
+- name: "pet"
+  description: "Operations about pets"
+- name: "store"
+- name: "user"
+  description: "Operations about user"
+schemes:
+- "http"
+- "https"
+paths:
+  /:
+    get:
+      summary: "testingRootPathResource"
+      description: ""
+      operationId: "testingRootPathResource"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "string"
+  /pet:
+    get:
+      tags:
+      - "pet"
+      summary: "Returns pet"
+      description: ""
+      operationId: "get"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Pet"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+    post:
+      tags:
+      - "pet"
+      summary: "Add a new pet to the store"
+      description: ""
+      operationId: "addPet"
+      consumes:
+      - "application/json"
+      - "application/xml"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "Pet object that needs to be added to the store"
+        required: true
+        schema:
+          $ref: "#/definitions/Pet"
+      responses:
+        405:
+          description: "Invalid input"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+    put:
+      tags:
+      - "pet"
+      summary: "Update an existing pet"
+      description: ""
+      operationId: "updatePet"
+      consumes:
+      - "application/json"
+      - "application/xml"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "Pet object that needs to be added to the store"
+        required: true
+        schema:
+          $ref: "#/definitions/Pet"
+      responses:
+        400:
+          description: "Invalid ID supplied"
+        404:
+          description: "Pet not found"
+        405:
+          description: "Validation exception"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+  /pet/findByStatus:
+    get:
+      tags:
+      - "pet"
+      summary: "Finds Pets by status"
+      description: "Multiple status values can be provided with comma seperated strings"
+      operationId: "findPetsByStatus"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "status"
+        in: "query"
+        description: "Status values that need to be considered for filter"
+        required: true
+        type: "array"
+        items:
+          type: "string"
+          default: "available"
+          enum:
+          - "available"
+          - "pending"
+          - "sold"
+        collectionFormat: "multi"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Pet"
+        400:
+          description: "Invalid status value"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+  /pet/findByTags:
+    get:
+      tags:
+      - "pet"
+      summary: "Finds Pets by tags"
+      description: "Muliple tags can be provided with comma seperated strings. Use\
+        \ tag1, tag2, tag3 for testing."
+      operationId: "findPetsByTags"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "tags"
+        in: "query"
+        description: "Tags to filter by"
+        required: true
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Pet"
+        400:
+          description: "Invalid tag value"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+      deprecated: true
+  /pet/pets/{petName}:
+    get:
+      tags:
+      - "pet"
+      summary: "Finds Pets by name"
+      description: ""
+      operationId: "findPetByPetName"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "petName"
+        in: "path"
+        description: "petName"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Pet"
+        400:
+          description: "Invalid status value"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+  /pet/test:
+    get:
+      tags:
+      - "pet"
+      summary: "Test pet as json string in query"
+      description: ""
+      operationId: "test"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "pet"
+        in: "query"
+        description: "describe Pet in json here"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Pet"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+  /pet/test/apiimplicitparams/{path-test-name}:
+    get:
+      tags:
+      - "pet"
+      summary: "Test apiimplicitparams"
+      description: ""
+      operationId: "testapiimplicitparams"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "header-test-name"
+        in: "header"
+        description: "header-test-value"
+        required: true
+        type: "string"
+        default: "z"
+      - name: "path-test-name"
+        in: "path"
+        description: "path-test-value"
+        required: true
+        type: "string"
+        default: "path-test-defaultValue"
+      - in: "body"
+        name: "body-test-name"
+        description: "body-test-value"
+        required: true
+        schema:
+          $ref: "#/definitions/Pet"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Pet"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+  /pet/test/extensions:
+    get:
+      tags:
+      - "pet"
+      summary: "testExtensions"
+      description: ""
+      operationId: "testingExtensions"
+      produces:
+      - "text/plain"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Pet"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+      x-firstExtension:
+        extensionName2: "extensionValue2"
+        extensionName1: "extensionValue1"
+      x-extensionName3: "extensionValue3"
+  /pet/test/testFormApiImplicitParams:
+    get:
+      tags:
+      - "pet"
+      summary: "Test testFormApiImplicitParams"
+      description: ""
+      operationId: "testFormApiImplicitParams"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "form-test-name"
+        in: "formData"
+        description: "form-test-value"
+        required: true
+        type: "array"
+        items:
+          type: "string"
+          default: "form-test-defaultValue"
+        collectionFormat: "multi"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Pet"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+  /pet/test/testingBasicAuth:
+    get:
+      tags:
+      - "pet"
+      summary: "testingBasicAuth"
+      description: ""
+      operationId: "testingBasicAuth"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "string"
+      security:
+      - basicAuth: []
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+  /pet/{petId}:
+    get:
+      tags:
+      - "pet"
+      summary: "Find pet by ID"
+      description: "Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate\
+        \ API error conditions"
+      operationId: "getPetById"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "petId"
+        in: "path"
+        description: "ID of pet that needs to be fetched"
+        required: true
+        type: "integer"
+        maximum: 5.0
+        minimum: 1.0
+        pattern: " [0-9]"
+        format: "int64"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Pet"
+        400:
+          description: "Invalid ID supplied"
+        404:
+          description: "Pet not found"
+      security:
+      - api_key: []
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+    post:
+      tags:
+      - "pet"
+      summary: "Updates a pet in the store with form data"
+      description: ""
+      operationId: "updatePetWithForm"
+      consumes:
+      - "application/x-www-form-urlencoded"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "petId"
+        in: "path"
+        description: "ID of pet that needs to be updated"
+        required: true
+        type: "string"
+      - name: "name"
+        in: "formData"
+        description: "Updated name of the pet"
+        required: false
+        type: "string"
+      - name: "status"
+        in: "formData"
+        description: "Updated status of the pet"
+        required: false
+        type: "string"
+        enum:
+          - value1
+          - value2
+      - name: "myHeader"
+        in: "header"
+        required: false
+        type: "string"
+        default: ""
+      - name: "intValue"
+        in: "header"
+        required: false
+        type: "integer"
+        default: ""
+        format: "int32"
+      - name: "myParentHeader"
+        in: "header"
+        description: "Header from parent"
+        required: false
+        type: "string"
+        default: ""
+      - name: "myHeaderOnMethod"
+        in: "header"
+        description: "Header annotated on method"
+        required: false
+        type: "string"
+        default: ""
+      - name: "myLongHeaderOnMethod"
+        in: "header"
+        description: "Long header annotated on method"
+        required: false
+        type: "integer"
+        default: ""
+        format: "int64"
+      responses:
+        405:
+          description: "Invalid input"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+    delete:
+      tags:
+      - "pet"
+      summary: "Deletes a pet"
+      description: ""
+      operationId: "removePet"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "api_key"
+        in: "header"
+        required: false
+        type: "string"
+        default: ""
+      - name: "petId"
+        in: "path"
+        description: "Pet id to delete"
+        required: true
+        type: "integer"
+        format: "int64"
+      responses:
+        400:
+          description: "Invalid pet value"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+  /pet/{petId}/testInjectParam:
+    post:
+      tags:
+      - "pet"
+      summary: "Updates a pet in the store with form data"
+      description: ""
+      operationId: "updatePetWithFormViaInjectParam"
+      consumes:
+      - "application/x-www-form-urlencoded"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "petId"
+        in: "path"
+        description: "ID of pet that needs to be updated"
+        required: true
+        type: "string"
+      - name: "name"
+        in: "formData"
+        description: "Updated name of the pet"
+        required: false
+        type: "string"
+      - name: "status"
+        in: "formData"
+        description: "Updated status of the pet"
+        required: false
+        type: "string"
+        enum:
+          - value1
+          - value2
+      - name: "myHeader"
+        in: "header"
+        required: false
+        type: "string"
+        default: ""
+      - name: "intValue"
+        in: "header"
+        required: false
+        type: "integer"
+        default: ""
+        format: "int32"
+      - name: "myParentHeader"
+        in: "header"
+        description: "Header from parent"
+        required: false
+        type: "string"
+        default: ""
+      - name: "myHeaderOnMethod"
+        in: "header"
+        description: "Header annotated on method"
+        required: false
+        type: "string"
+        default: ""
+      - name: "myLongHeaderOnMethod"
+        in: "header"
+        description: "Long header annotated on method"
+        required: false
+        type: "integer"
+        default: ""
+        format: "int64"
+      responses:
+        405:
+          description: "Invalid input"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+  /store/order:
+    post:
+      tags:
+      - "store"
+      summary: "Place an order for a pet"
+      description: ""
+      operationId: "placeOrder"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "order placed for purchasing the pet"
+        required: true
+        schema:
+          $ref: "#/definitions/Order"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Order"
+        400:
+          description: "Invalid Order"
+  /store/order/{orderId}:
+    get:
+      tags:
+      - "store"
+      summary: "Find purchase order by ID"
+      description: "For valid response try integer IDs with value <= 5 or > 10. Other\
+        \ values will generated exceptions"
+      operationId: "getOrderById"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "orderId"
+        in: "path"
+        description: "ID of pet that needs to be fetched"
+        required: true
+        type: "string"
+        maximum: 5.0
+        minimum: 1.0
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Order"
+        400:
+          description: "Invalid ID supplied"
+        404:
+          description: "Order not found"
+    delete:
+      tags:
+      - "store"
+      summary: "Delete purchase order by ID"
+      description: "For valid response try integer IDs with value < 1000. Anything\
+        \ above 1000 or nonintegers will generate API errors"
+      operationId: "deleteOrder"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "orderId"
+        in: "path"
+        description: "ID of the order that needs to be deleted"
+        required: true
+        type: "string"
+        minimum: 1.0
+      responses:
+        400:
+          description: "Invalid ID supplied"
+        404:
+          description: "Order not found"
+  /store/pingGet:
+    get:
+      tags:
+      - "store"
+      summary: "Simple ping endpoint"
+      description: ""
+      operationId: "pingGet"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "Successful request - see response for 'pong'"
+          schema:
+            type: "string"
+  /store/pingPost:
+    post:
+      tags:
+      - "store"
+      summary: "Simple ping endpoint"
+      description: ""
+      operationId: "pingPost"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "Successful request - see response for 'pong'"
+          schema:
+            type: "string"
+  /store/pingPut:
+    put:
+      tags:
+      - "store"
+      summary: "Simple ping endpoint"
+      description: ""
+      operationId: "pingPut"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "Successful request - see response for 'pong'"
+          schema:
+            type: "string"
+  /user:
+    post:
+      tags:
+      - "user"
+      summary: "Create user"
+      description: "This can only be done by the logged in user."
+      operationId: "createUser"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "Created user object"
+        required: true
+        schema:
+          $ref: "#/definitions/User"
+      responses:
+        default:
+          description: "successful operation"
+  /user/createWithArray:
+    post:
+      tags:
+      - "user"
+      summary: "Creates list of users with given input array"
+      description: ""
+      operationId: "createUsersWithArrayInput"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "List of user object"
+        required: true
+        schema:
+          type: "array"
+          items:
+            $ref: "#/definitions/User"
+      responses:
+        default:
+          description: "successful operation"
+  /user/createWithList:
+    post:
+      tags:
+      - "user"
+      summary: "Creates list of users with given input array"
+      description: ""
+      operationId: "createUsersWithListInput"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "List of user object"
+        required: true
+        schema:
+          type: "array"
+          items:
+            $ref: "#/definitions/User"
+      responses:
+        default:
+          description: "successful operation"
+  /user/login:
+    get:
+      tags:
+      - "user"
+      summary: "Logs user into the system"
+      description: ""
+      operationId: "loginUser"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "username"
+        in: "query"
+        description: "The user name for login"
+        required: true
+        type: "string"
+      - name: "password"
+        in: "query"
+        description: "The password for login in clear text"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "string"
+        400:
+          description: "Invalid username/password supplied"
+  /user/logout:
+    get:
+      tags:
+      - "user"
+      summary: "Logs out current logged in user session"
+      description: ""
+      operationId: "logoutUser"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters: []
+      responses:
+        default:
+          description: "successful operation"
+  /user/{username}:
+    get:
+      tags:
+      - "user"
+      summary: "Get user by user name"
+      description: ""
+      operationId: "getUserByName"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "username"
+        in: "path"
+        description: "The name that needs to be fetched. Use user1 for testing. "
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/User"
+        400:
+          description: "Invalid username supplied"
+        404:
+          description: "User not found"
+    put:
+      tags:
+      - "user"
+      summary: "Updated user"
+      description: "This can only be done by the logged in user."
+      operationId: "updateUser"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "username"
+        in: "path"
+        description: "name that need to be deleted"
+        required: true
+        type: "string"
+      - in: "body"
+        name: "body"
+        description: "Updated user object"
+        required: true
+        schema:
+          $ref: "#/definitions/User"
+      responses:
+        400:
+          description: "Invalid user supplied"
+        404:
+          description: "User not found"
+    delete:
+      tags:
+      - "user"
+      summary: "Delete user"
+      description: "This can only be done by the logged in user."
+      operationId: "deleteUser"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "username"
+        in: "path"
+        description: "The name that needs to be deleted"
+        required: true
+        type: "string"
+      responses:
+        400:
+          description: "Invalid username supplied"
+        404:
+          description: "User not found"
+securityDefinitions:
+  api_key:
+    type: "apiKey"
+    name: "api_key"
+    in: "header"
+  basicAuth:
+    type: "basic"
+  petstore_auth:
+    type: "oauth2"
+    authorizationUrl: "http://swagger.io/api/oauth/dialog"
+    flow: "implicit"
+    scopes:
+      write:pets: "modify pets in your account"
+      read:pets: "read your pets"
+definitions:
+  Category:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+      name:
+        type: "string"
+    xml:
+      name: "Category"
+  Order:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+      petId:
+        type: "integer"
+        format: "int64"
+      quantity:
+        type: "integer"
+        format: "int32"
+      shipDate:
+        type: "string"
+        format: "date-time"
+      status:
+        type: "string"
+        description: "Order Status"
+        enum:
+        - "placed"
+        - "approved"
+        - "delivered"
+      complete:
+        type: "boolean"
+        default: false
+    xml:
+      name: "Order"
+  Pet:
+    type: "object"
+    required:
+    - "name"
+    - "photoUrls"
+    properties:
+      id:
+        type: "string"
+      category:
+        $ref: "#/definitions/Category"
+      name:
+        type: "string"
+        example: "doggie"
+      photoUrls:
+        type: "array"
+        xml:
+          name: "photoUrl"
+          wrapped: true
+        items:
+          type: "string"
+      tags:
+        type: "array"
+        xml:
+          name: "tag"
+          wrapped: true
+        items:
+          $ref: "#/definitions/Tag"
+      status:
+        type: "string"
+        description: "pet status in the store"
+        enum:
+        - "available"
+        - "pending"
+        - "sold"
+    xml:
+      name: "Pet"
+  Tag:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+      name:
+        type: "string"
+    xml:
+      name: "Tag"
+  User:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+      username:
+        type: "string"
+      firstName:
+        type: "string"
+      lastName:
+        type: "string"
+      email:
+        type: "string"
+      password:
+        type: "string"
+      phone:
+        type: "string"
+      userStatus:
+        type: "integer"
+        format: "int32"
+        example: "2"
+        description: "User Status"
+    xml:
+      name: "User"


### PR DESCRIPTION
Added a new configuration element in ApiSource `<modelConverters>` which can be used to add custom ModelConverters to the swagger generation.

I specifically needed the `io.swagger.validator.BeanValidator` class in order to understand hibernate validation annotations.