### PR TITLE
Correct handling of generic response types in Spring MVC controllers

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
@@ -282,7 +282,7 @@ public abstract class AbstractReader {
         return tagsMap;
     }
 
-    boolean isPrimitive(Class<?> cls) {
+    boolean isPrimitive(Type cls) {
         boolean out = false;
 
         Property property = ModelConverters.getInstance().readAsProperty(cls);

--- a/src/test/java/com/github/kongchen/smp/integration/SpringMvcTest.java
+++ b/src/test/java/com/github/kongchen/smp/integration/SpringMvcTest.java
@@ -125,7 +125,7 @@ public class SpringMvcTest extends AbstractMojoTestCase {
                 String actual = actualReader.readLine();
                 if (expect == null && actual == null)
                     break;
-                Assert.assertEquals(expect.trim(), actual.trim(), "" + count);
+                Assert.assertEquals(actual.trim(), expect.trim(), "" + count);
 
             }
 

--- a/src/test/resources/expectedOutput/swagger-spring.json
+++ b/src/test/resources/expectedOutput/swagger-spring.json
@@ -325,6 +325,15 @@
           }
         } ],
         "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/Pet"
+              }
+            }
+          },
           "405" : {
             "description" : "Invalid input"
           }

--- a/src/test/resources/expectedOutput/swagger-spring.yaml
+++ b/src/test/resources/expectedOutput/swagger-spring.yaml
@@ -305,6 +305,12 @@ paths:
           items:
             $ref: "#/definitions/Pet"
       responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Pet"
         405:
           description: "Invalid input"
       security:

--- a/src/test/resources/sample-springmvc.html
+++ b/src/test/resources/sample-springmvc.html
@@ -857,6 +857,7 @@ If you wish to paginate the results of this API, supply offset and limit query p
 
 | Status Code | Reason      | Response Model |
 |-------------|-------------|----------------|
+| 200    | successful operation | Array[<a href="#/definitions/Pet">Pet</a>]|
 | 405    | Invalid input |  - |
 
 


### PR DESCRIPTION
The current version has a bug in the handling of the generic response types of Controllers. The generic parameters of the response class got ignored. For example:
`
@RequestMapping
@ApiOperation("Returns a rainbow colored pony.")
BaseRequest<Pony> getPony();
`
Got interpreted as:
`
@RequestMapping
@ApiOperation("Returns a rainbow colored pony.")
BaseRequest getPony();
`
This pull request also provides correct parsing of ResponseEntities, for details see the updated unit tests.