### PR TITLE
Spring MVC map of path variables support

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
@@ -517,6 +517,10 @@ public abstract class AbstractReader {
     }
 
     protected void readImplicitParameters(Method method, Operation operation) {
+        readImplicitParameters(method, operation, null);
+    }
+    
+    protected void readImplicitParameters(Method method, Operation operation, List<String> pathParamNames) {
         ApiImplicitParams implicitParams = AnnotationUtils.findAnnotation(method, ApiImplicitParams.class);
         if (implicitParams != null && implicitParams.value().length > 0) {
             for (ApiImplicitParam param : implicitParams.value()) {
@@ -530,6 +534,9 @@ public abstract class AbstractReader {
 
                 Parameter p = readImplicitParam(param, cls);
                 if (p != null) {
+                	if(pathParamNames != null && p instanceof PathParameter){
+                		pathParamNames.add(p.getName());
+                	}
                     operation.addParameter(p);
                 }
             }

--- a/src/test/java/com/wordnik/springmvc/PetResource.java
+++ b/src/test/java/com/wordnik/springmvc/PetResource.java
@@ -21,7 +21,9 @@ import com.wordnik.sample.data.PetData;
 import com.wordnik.sample.exception.NotFoundException;
 import com.wordnik.sample.model.PaginationHelper;
 import com.wordnik.sample.model.Pet;
+
 import io.swagger.annotations.*;
+
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -31,6 +33,7 @@ import javax.validation.constraints.Size;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+
 import java.util.*;
 
 @Api(value = "/pet", description = "Operations about pets", authorizations = {
@@ -277,4 +280,11 @@ public class PetResource {
     public String testingBasicAuth() {
         return "testingBasicAuth";
     }
+    
+	@ApiOperation(value = "testingMapPathVariables", response = Void.class)
+	@ApiResponses(value = { @ApiResponse(code = 200, message = "successful operation") })
+	@RequestMapping(value = "/testPathParams/{abc}/{efg}", method = RequestMethod.GET)
+	public ResponseEntity<Void> testingMapPathVariables(@PathVariable Map<String, String> pathVariables){
+		return new ResponseEntity<Void>(HttpStatus.OK);
+	}
 }

--- a/src/test/java/com/wordnik/springmvc/PetResource.java
+++ b/src/test/java/com/wordnik/springmvc/PetResource.java
@@ -287,4 +287,15 @@ public class PetResource {
 	public ResponseEntity<Void> testingMapPathVariables(@PathVariable Map<String, String> pathVariables){
 		return new ResponseEntity<Void>(HttpStatus.OK);
 	}
+	
+	@ApiOperation(value = "testingMapPathVariablesImplicit", response = Void.class)
+	@ApiResponses(value = { @ApiResponse(code = 200, message = "successful operation") })
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "abc", dataType = "string", paramType = "path"),
+		@ApiImplicitParam(name = "efg", dataType = "integer", paramType = "path")
+	})
+	@RequestMapping(value = "/testPathParamsImpl/{abc}/{efg}", method = RequestMethod.GET)
+	public ResponseEntity<Void> testingMapPathVariablesImplicit(@PathVariable Map<String, String> pathVariables){
+		return new ResponseEntity<Void>(HttpStatus.OK);
+	}
 }

--- a/src/test/resources/expectedOutput/swagger-spring.json
+++ b/src/test/resources/expectedOutput/swagger-spring.json
@@ -705,6 +705,34 @@
         }
       }
     },
+    "/pet/testPathParams/{abc}/{efg}" : {
+      "get" : {
+      	"tags" : [ "pet" ],
+        "summary" : "testingMapPathVariables",
+        "description" : "",
+        "operationId" : "testingMapPathVariables",
+        "produces" : [ "application/json", "application/xml" ],
+        "parameters" : [ { 
+          "name" : "abc",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "efg",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : { 
+          "200" : { 
+            "description" : "successful operation"
+          }   
+        },
+        "security" : [ {
+          "petstore_auth" : [ "write:pets", "read:pets" ]
+        } ]  
+      }
+    },
     "/user" : {
       "post" : {
         "tags" : [ "user" ],

--- a/src/test/resources/expectedOutput/swagger-spring.json
+++ b/src/test/resources/expectedOutput/swagger-spring.json
@@ -733,6 +733,34 @@
         } ]  
       }
     },
+	"/pet/testPathParamsImpl/{abc}/{efg}" : {
+      "get" : {
+      	"tags" : [ "pet" ],
+        "summary" : "testingMapPathVariablesImplicit",
+        "description" : "",
+        "operationId" : "testingMapPathVariablesImplicit",
+        "produces" : [ "application/json", "application/xml" ],
+        "parameters" : [ { 
+          "name" : "abc",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "efg",
+          "in" : "path",
+          "required" : true,
+          "type" : "integer"
+        } ],
+        "responses" : { 
+          "200" : { 
+            "description" : "successful operation"
+          }   
+        },
+        "security" : [ {
+          "petstore_auth" : [ "write:pets", "read:pets" ]
+        } ]  
+      }
+    },
     "/user" : {
       "post" : {
         "tags" : [ "user" ],

--- a/src/test/resources/expectedOutput/swagger-spring.yaml
+++ b/src/test/resources/expectedOutput/swagger-spring.yaml
@@ -673,6 +673,35 @@ paths:
           petstore_auth: 
             - "write:pets"
             - "read:pets"
+  /pet/testPathParamsImpl/{abc}/{efg}: 
+    get: 
+      tags: 
+        - "pet"
+      summary: "testingMapPathVariablesImplicit"
+      description: ""
+      operationId: "testingMapPathVariablesImplicit"
+      produces: 
+        - "application/json"
+        - "application/xml"
+      parameters: 
+        - 
+          name: "abc"
+          in: "path"
+          required: true
+          type: "string"
+        - 
+          name: "efg"
+          in: "path"
+          required: true
+          type: "integer"
+      responses: 
+        200: 
+          description: "successful operation"
+      security: 
+        - 
+          petstore_auth: 
+            - "write:pets"
+            - "read:pets"
   /user:
     post:
       tags:

--- a/src/test/resources/expectedOutput/swagger-spring.yaml
+++ b/src/test/resources/expectedOutput/swagger-spring.yaml
@@ -644,6 +644,35 @@ paths:
           description: "successful operation"
           schema:
             type: "string"
+  /pet/testPathParams/{abc}/{efg}: 
+    get: 
+      tags: 
+        - "pet"
+      summary: "testingMapPathVariables"
+      description: ""
+      operationId: "testingMapPathVariables"
+      produces: 
+        - "application/json"
+        - "application/xml"
+      parameters: 
+        - 
+          name: "abc"
+          in: "path"
+          required: true
+          type: "string"
+        - 
+          name: "efg"
+          in: "path"
+          required: true
+          type: "string"
+      responses: 
+        200: 
+          description: "successful operation"
+      security: 
+        - 
+          petstore_auth: 
+            - "write:pets"
+            - "read:pets"
   /user:
     post:
       tags:

--- a/src/test/resources/sample-springmvc.html
+++ b/src/test/resources/sample-springmvc.html
@@ -935,6 +935,105 @@ If you wish to paginate the results of this API, supply offset and limit query p
 
 
 
+## /pet/testPathParams/{abc}/{efg}
+
+
+### GET
+
+<a id="testingMapPathVariables">testingMapPathVariables</a>
+
+
+
+
+
+
+#### Security
+
+
+
+
+* petstore_auth
+   * write:pets
+   * read:pets
+
+
+
+
+#### Request
+
+
+
+##### Parameters
+
+<table border="1">
+    <tr>
+        <th>Name</th>
+        <th>Located in</th>
+        <th>Required</th>
+        <th>Description</th>
+        <th>Default</th>
+        <th>Schema</th>
+    </tr>
+
+
+
+<tr>
+    <th>abc</th>
+    <td>path</td>
+    <td>yes</td>
+    <td></td>
+    <td> - </td>
+
+    
+            <td>string </td>
+    
+
+</tr>
+
+<tr>
+    <th>efg</th>
+    <td>path</td>
+    <td>yes</td>
+    <td></td>
+    <td> - </td>
+
+    
+            <td>string </td>
+    
+
+</tr>
+
+
+</table>
+
+
+
+#### Response
+
+**Content-Type: ** application/xml, application/json
+
+
+| Status Code | Reason      | Response Model |
+|-------------|-------------|----------------|
+| 200    | successful operation |  - |
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 ## /pet/testing
 
 

--- a/src/test/resources/sample-springmvc.html
+++ b/src/test/resources/sample-springmvc.html
@@ -1034,6 +1034,105 @@ If you wish to paginate the results of this API, supply offset and limit query p
 
 
 
+## /pet/testPathParamsImpl/{abc}/{efg}
+
+
+### GET
+
+<a id="testingMapPathVariablesImplicit">testingMapPathVariablesImplicit</a>
+
+
+
+
+
+
+#### Security
+
+
+
+
+* petstore_auth
+   * write:pets
+   * read:pets
+
+
+
+
+#### Request
+
+
+
+##### Parameters
+
+<table border="1">
+    <tr>
+        <th>Name</th>
+        <th>Located in</th>
+        <th>Required</th>
+        <th>Description</th>
+        <th>Default</th>
+        <th>Schema</th>
+    </tr>
+
+
+
+<tr>
+    <th>abc</th>
+    <td>path</td>
+    <td>yes</td>
+    <td></td>
+    <td> - </td>
+
+    
+            <td>string </td>
+    
+
+</tr>
+
+<tr>
+    <th>efg</th>
+    <td>path</td>
+    <td>yes</td>
+    <td></td>
+    <td> - </td>
+
+    
+            <td>integer </td>
+    
+
+</tr>
+
+
+</table>
+
+
+
+#### Response
+
+**Content-Type: ** application/xml, application/json
+
+
+| Status Code | Reason      | Response Model |
+|-------------|-------------|----------------|
+| 200    | successful operation |  - |
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 ## /pet/testing
 
 


### PR DESCRIPTION
Spring MVC  [PathVariable annotation](http://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/bind/annotation/PathVariable.html) allows you to specify a method parameter of `Map<String, String>`  where the map is populated with all path variable names and values like so

    @ApiOperation(value = "path params", notes = "testing map of path params", response = Void.class)
    @ApiResponses(value = { @ApiResponse(code = 200, message = "successful operation") })
    @RequestMapping(value = "/testPathParams/{abc}/{efg}", method = RequestMethod.GET)
    public ResponseEntity<Void> testMapPathVars(@PathVariable Map<String, String> pathVariables){
        ...
        return new ResponseEntity<Void>(HttpStatus.OK);
    }

This currently produces the following operation

    "/testPathParams/{abc}/{efg}" : { 
      "get" : { 
        "tags" : [ "specific_alarm" ],
        "summary" : "path params",
        "description" : "testing map of path params",
        "operationId" : "testMapPathVars",
        "parameters" : [ { 
          "name" : "", 
          "in" : "path",
          "required" : true,
          "type" : "object"
        } ],
        "responses" : { 
          "200" : { 
            "description" : "successful operation"
          }   
        }   
      }   
    }

when it should produce something like this

    "/testPathParams/{abc}/{efg}" : { 
      "get" : { 
        "tags" : [ "specific_alarm" ],
        "summary" : "path params",
        "description" : "testing map of path params",
        "operationId" : "testMapPathVars",
        "parameters" : [ { 
          "name" : "abc",
          "in" : "path",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "efg",
          "in" : "path",
          "required" : true,
          "type" : "string"
        } ],
        "responses" : { 
          "200" : { 
            "description" : "successful operation"
          }   
        }   
      }
    }

Additionally, if there is an ApiImplicitParam annotation referring to a variable in the path this should probably be used to create the parameter in the spec, which this PR does.