### PR TITLE
Changed object mapper for consistency

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/AbstractDocumentSource.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/AbstractDocumentSource.java
@@ -21,6 +21,7 @@ import io.swagger.converter.ModelConverters;
 import io.swagger.models.Scheme;
 import io.swagger.models.Swagger;
 import io.swagger.models.properties.Property;
+import io.swagger.util.Json;
 import io.swagger.util.Yaml;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -154,7 +155,7 @@ public abstract class AbstractDocumentSource {
     }
 
     public void loadModelModifier() throws GenerateException, IOException {
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = Json.mapper();
         if (apiSource.isUseJAXBAnnotationProcessor()) {
             objectMapper.registerModule(new JaxbAnnotationModule());
             objectMapper.registerModule(new JaxbAnnotationModule());


### PR DESCRIPTION
Hello,

In the [ModelConverters](https://github.com/swagger-api/swagger-core/blob/master/modules/swagger-core/src/main/java/io/swagger/converter/ModelConverters.java) the object mapper that is used is Json.mapper(). In ModelModifier a new object mapper is created instead. 

This change makes the two more consistent. It also makes it possible to modify the ObjectMapper used by the ModelModifier, which is useful for projects that don't serialize properly with the default ObjectMapper.