### PR TITLE
Issue 304

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
@@ -41,6 +41,7 @@ import io.swagger.models.properties.MapProperty;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.RefProperty;
 import io.swagger.util.ParameterProcessor;
+import io.swagger.util.PathUtils;
 import org.apache.commons.lang3.reflect.TypeUtils;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -131,38 +132,7 @@ public abstract class AbstractReader {
     }
 
     protected String parseOperationPath(String operationPath, Map<String, String> regexMap) {
-        // If the operation's path is a simple "/", don't bother parsing - just return it as is.
-        if (operationPath.equalsIgnoreCase("/")) {
-            return operationPath;
-        }
-
-        String[] pps = operationPath.split("/");
-        String[] pathParts = new String[pps.length];
-
-        for (int i = 0; i < pps.length; i++) {
-            String p = pps[i];
-            if (p.startsWith("{")) {
-                int pos = p.indexOf(":");
-                if (pos > 0) {
-                    String left = p.substring(1, pos);
-                    String right = p.substring(pos + 1, p.length() - 1);
-                    pathParts[i] = "{" + left.trim() + "}";
-                    regexMap.put(left.trim(), right);
-                } else {
-                    pathParts[i] = p;
-                }
-            } else {
-                pathParts[i] = p;
-            }
-        }
-        StringBuilder pathBuilder = new StringBuilder();
-        for (String pathPart : pathParts) {
-            if (!pathPart.isEmpty()) {
-                pathBuilder.append("/").append(pathPart);
-            }
-        }
-        operationPath = pathBuilder.toString();
-        return operationPath;
+        return PathUtils.parsePath(operationPath, regexMap);
     }
 
     protected void updateOperationParameters(List<Parameter> parentParameters, Map<String, String> regexMap, Operation operation) {

--- a/src/test/java/com/wordnik/jaxrs/PetResource.java
+++ b/src/test/java/com/wordnik/jaxrs/PetResource.java
@@ -81,7 +81,7 @@ public class PetResource {
     }
     //contrived example test case for swagger-maven-plugin issue #304
     @GET
-    @Path("/{startId : [0-9]}:{endId : [0-9]}")
+    @Path("/{startId : [0-9]{1,2}}:{endId : [0-9]{1,2}}")
     @ApiOperation(value = "Find pet(s) by ID",
             notes = "This is a contrived example of a path segment containing multiple path parameters, separated by a character which may be present in the path parameter template. You may think that it returns a range of pets from startId to endId, inclusive, but it doesn't.",
             response = Pet.class,
@@ -90,8 +90,8 @@ public class PetResource {
     @ApiResponses(value = {@ApiResponse(code = 400, message = "Invalid ID supplied"),
             @ApiResponse(code = 404, message = "Pet not found")})
     public Response getPetsById(
-            @ApiParam(value = "start ID of pets that need to be fetched", allowableValues = "range[1,5]", required = true) @PathParam("startId") Long startId,
-            @ApiParam(value = "end ID of pets that need to be fetched", allowableValues = "range[1,5]", required = true) @PathParam("endId") Long endId)
+            @ApiParam(value = "start ID of pets that need to be fetched", allowableValues = "range[1,99]", required = true) @PathParam("startId") Long startId,
+            @ApiParam(value = "end ID of pets that need to be fetched", allowableValues = "range[1,99]", required = true) @PathParam("endId") Long endId)
             throws com.wordnik.sample.exception.NotFoundException {
         Pet pet = petData.getPetbyId(startId);
         if (pet != null) {
@@ -135,7 +135,7 @@ public class PetResource {
     }
 
     @GET
-    @Path("/pets/{petName}")
+    @Path("/pets/{petName : [^/]*}")
     @ApiOperation(value = "Finds Pets by name",
             response = Pet.class,
             responseContainer = "List")

--- a/src/test/java/com/wordnik/jaxrs/PetResource.java
+++ b/src/test/java/com/wordnik/jaxrs/PetResource.java
@@ -79,6 +79,27 @@ public class PetResource {
             throw new com.wordnik.sample.exception.NotFoundException(404, "Pet not found");
         }
     }
+    //contrived example test case for swagger-maven-plugin issue #304
+    @GET
+    @Path("/{startId : [0-9]}:{endId : [0-9]}")
+    @ApiOperation(value = "Find pet(s) by ID",
+            notes = "This is a contrived example of a path segment containing multiple path parameters, separated by a character which may be present in the path parameter template. You may think that it returns a range of pets from startId to endId, inclusive, but it doesn't.",
+            response = Pet.class,
+            authorizations = @Authorization(value = "api_key")
+    )
+    @ApiResponses(value = {@ApiResponse(code = 400, message = "Invalid ID supplied"),
+            @ApiResponse(code = 404, message = "Pet not found")})
+    public Response getPetsById(
+            @ApiParam(value = "start ID of pets that need to be fetched", allowableValues = "range[1,5]", required = true) @PathParam("startId") Long startId,
+            @ApiParam(value = "end ID of pets that need to be fetched", allowableValues = "range[1,5]", required = true) @PathParam("endId") Long endId)
+            throws com.wordnik.sample.exception.NotFoundException {
+        Pet pet = petData.getPetbyId(startId);
+        if (pet != null) {
+            return Response.ok().entity(pet).build();
+        } else {
+            throw new com.wordnik.sample.exception.NotFoundException(404, "Pet not found");
+        }
+    }
 
     @DELETE
     @Path("/{petId}")

--- a/src/test/resources/expectedOutput/swagger-with-converter.json
+++ b/src/test/resources/expectedOutput/swagger-with-converter.json
@@ -552,6 +552,66 @@
         ]
       }
     },
+    "/pet/{startId}:{endId}": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Find pet(s) by ID",
+        "description": "This is a contrived example of a path segment containing multiple path parameters, separated by a character which may be present in the path parameter template. You may think that it returns a range of pets from startId to endId, inclusive, but it doesn't.",
+        "operationId": "getPetsById",
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
+        "parameters" : [ {
+          "name" : "startId",
+          "in" : "path",
+          "description" : "start ID of pets that need to be fetched",
+          "required" : true,
+          "type" : "integer",
+          "maximum" : 5.0,
+          "minimum" : 1.0,
+          "pattern" : "[0-9]",
+          "format" : "int64"
+        }, {
+          "name" : "endId",
+          "in" : "path",
+          "description" : "end ID of pets that need to be fetched",
+          "required" : true,
+          "type" : "integer",
+          "maximum" : 5.0,
+          "minimum" : 1.0,
+          "pattern" : "[0-9]",
+          "format" : "int64"
+        } ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          },
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
     "/pet/{petId}": {
       "get": {
         "tags": [
@@ -573,7 +633,7 @@
             "type": "integer",
             "maximum": 5.0,
             "minimum": 1.0,
-            "pattern": " [0-9]",
+            "pattern": "[0-9]",
             "format": "int64"
           }
         ],

--- a/src/test/resources/expectedOutput/swagger-with-converter.json
+++ b/src/test/resources/expectedOutput/swagger-with-converter.json
@@ -288,7 +288,8 @@
             "in": "path",
             "description": "petName",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "[^/]*"
           }
         ],
         "responses": {
@@ -570,9 +571,9 @@
           "description" : "start ID of pets that need to be fetched",
           "required" : true,
           "type" : "integer",
-          "maximum" : 5.0,
+          "maximum" : 99.0,
           "minimum" : 1.0,
-          "pattern" : "[0-9]",
+          "pattern" : "[0-9]{1,2}",
           "format" : "int64"
         }, {
           "name" : "endId",
@@ -580,9 +581,9 @@
           "description" : "end ID of pets that need to be fetched",
           "required" : true,
           "type" : "integer",
-          "maximum" : 5.0,
+          "maximum" : 99.0,
           "minimum" : 1.0,
-          "pattern" : "[0-9]",
+          "pattern" : "[0-9]{1,2}",
           "format" : "int64"
         } ],
         "responses": {

--- a/src/test/resources/expectedOutput/swagger-with-converter.yaml
+++ b/src/test/resources/expectedOutput/swagger-with-converter.yaml
@@ -196,6 +196,7 @@ paths:
         description: "petName"
         required: true
         type: "string"
+        pattern: "[^/]*"
       responses:
         200:
           description: "successful operation"
@@ -380,19 +381,19 @@ paths:
         required: true
         description: "start ID of pets that need to be fetched"
         type: "integer"
-        maximum: 5.0
+        maximum: 99.0
         minimum: 1.0
         format: "int64"
-        pattern: "[0-9]"
+        pattern: "[0-9]{1,2}"
       - name: "endId"
         in: "path"
         description: "end ID of pets that need to be fetched"
         required: true
         type: "integer"
-        maximum: 5.0
+        maximum: 99.0
         minimum: 1.0
         format: "int64"
-        pattern: "[0-9]"
+        pattern: "[0-9]{1,2}"
       responses:
         200:
           description: "successful operation"

--- a/src/test/resources/expectedOutput/swagger-with-converter.yaml
+++ b/src/test/resources/expectedOutput/swagger-with-converter.yaml
@@ -364,6 +364,47 @@ paths:
       - petstore_auth:
         - "write:pets"
         - "read:pets"
+  /pet/{startId}:{endId}:
+    get:
+      tags:
+      - "pet"
+      summary: "Find pet(s) by ID"
+      description: "This is a contrived example of a path segment containing multiple path parameters, separated by a character which may be present in the path parameter template. You may think that it returns a range of pets from startId to endId, inclusive, but it doesn't."
+      operationId: "getPetsById"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "startId"
+        in: "path"
+        description: "start ID of pets that needs to be fetched"
+        required: true
+        type: "integer"
+        maximum: 5.0
+        minimum: 1.0
+        format: "int64"
+      - name: "endId"
+        in: "path"
+        description: "end ID of pets that needs to be fetched"
+        required: true
+        type: "integer"
+        maximum: 5.0
+        minimum: 1.0
+        format: "int64"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Pet"
+        400:
+          description: "Invalid ID supplied"
+        404:
+          description: "Pet not found"
+      security:
+      - api_key: []
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
   /pet/{petId}:
     get:
       tags:
@@ -383,7 +424,7 @@ paths:
         type: "integer"
         maximum: 5.0
         minimum: 1.0
-        pattern: " [0-9]"
+        pattern: "[0-9]"
         format: "int64"
       responses:
         200:

--- a/src/test/resources/expectedOutput/swagger-with-converter.yaml
+++ b/src/test/resources/expectedOutput/swagger-with-converter.yaml
@@ -377,20 +377,22 @@ paths:
       parameters:
       - name: "startId"
         in: "path"
-        description: "start ID of pets that needs to be fetched"
         required: true
+        description: "start ID of pets that need to be fetched"
         type: "integer"
         maximum: 5.0
         minimum: 1.0
         format: "int64"
+        pattern: "[0-9]"
       - name: "endId"
         in: "path"
-        description: "end ID of pets that needs to be fetched"
+        description: "end ID of pets that need to be fetched"
         required: true
         type: "integer"
         maximum: 5.0
         minimum: 1.0
         format: "int64"
+        pattern: "[0-9]"
       responses:
         200:
           description: "successful operation"

--- a/src/test/resources/expectedOutput/swagger.json
+++ b/src/test/resources/expectedOutput/swagger.json
@@ -552,6 +552,66 @@
         ]
       }
     },
+    "/pet/{startId}:{endId}": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Find pet(s) by ID",
+        "description": "This is a contrived example of a path segment containing multiple path parameters, separated by a character which may be present in the path parameter template. You may think that it returns a range of pets from startId to endId, inclusive, but it doesn't.",
+        "operationId": "getPetsById",
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
+        "parameters" : [ {
+          "name" : "startId",
+          "in" : "path",
+          "description" : "start ID of pets that need to be fetched",
+          "required" : true,
+          "type" : "integer",
+          "maximum" : 5.0,
+          "minimum" : 1.0,
+          "pattern" : "[0-9]",
+          "format" : "int64"
+        }, {
+          "name" : "endId",
+          "in" : "path",
+          "description" : "end ID of pets that need to be fetched",
+          "required" : true,
+          "type" : "integer",
+          "maximum" : 5.0,
+          "minimum" : 1.0,
+          "pattern" : "[0-9]",
+          "format" : "int64"
+        } ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          },
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
     "/pet/{petId}": {
       "get": {
         "tags": [
@@ -573,7 +633,7 @@
             "type": "integer",
             "maximum": 5.0,
             "minimum": 1.0,
-            "pattern": " [0-9]",
+            "pattern": "[0-9]",
             "format": "int64"
           }
         ],

--- a/src/test/resources/expectedOutput/swagger.json
+++ b/src/test/resources/expectedOutput/swagger.json
@@ -288,7 +288,8 @@
             "in": "path",
             "description": "petName",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "[^/]*"
           }
         ],
         "responses": {
@@ -570,9 +571,9 @@
           "description" : "start ID of pets that need to be fetched",
           "required" : true,
           "type" : "integer",
-          "maximum" : 5.0,
+          "maximum" : 99.0,
           "minimum" : 1.0,
-          "pattern" : "[0-9]",
+          "pattern" : "[0-9]{1,2}",
           "format" : "int64"
         }, {
           "name" : "endId",
@@ -580,9 +581,9 @@
           "description" : "end ID of pets that need to be fetched",
           "required" : true,
           "type" : "integer",
-          "maximum" : 5.0,
+          "maximum" : 99.0,
           "minimum" : 1.0,
-          "pattern" : "[0-9]",
+          "pattern" : "[0-9]{1,2}",
           "format" : "int64"
         } ],
         "responses": {

--- a/src/test/resources/expectedOutput/swagger.yaml
+++ b/src/test/resources/expectedOutput/swagger.yaml
@@ -377,20 +377,22 @@ paths:
       parameters:
       - name: "startId"
         in: "path"
-        description: "start ID of pets that needs to be fetched"
+        description: "start ID of pets that need to be fetched"
         required: true
         type: "integer"
         maximum: 5.0
         minimum: 1.0
         format: "int64"
+        pattern: "[0-9]"
       - name: "endId"
         in: "path"
-        description: "end ID of pets that needs to be fetched"
+        description: "end ID of pets that need to be fetched"
         required: true
         type: "integer"
         maximum: 5.0
         minimum: 1.0
         format: "int64"
+        pattern: "[0-9]"
       responses:
         200:
           description: "successful operation"

--- a/src/test/resources/expectedOutput/swagger.yaml
+++ b/src/test/resources/expectedOutput/swagger.yaml
@@ -196,6 +196,7 @@ paths:
         description: "petName"
         required: true
         type: "string"
+        pattern: "[^/]*"
       responses:
         200:
           description: "successful operation"
@@ -380,19 +381,19 @@ paths:
         description: "start ID of pets that need to be fetched"
         required: true
         type: "integer"
-        maximum: 5.0
+        maximum: 99.0
         minimum: 1.0
         format: "int64"
-        pattern: "[0-9]"
+        pattern: "[0-9]{1,2}"
       - name: "endId"
         in: "path"
         description: "end ID of pets that need to be fetched"
         required: true
         type: "integer"
-        maximum: 5.0
+        maximum: 99.0
         minimum: 1.0
         format: "int64"
-        pattern: "[0-9]"
+        pattern: "[0-9]{1,2}"
       responses:
         200:
           description: "successful operation"

--- a/src/test/resources/expectedOutput/swagger.yaml
+++ b/src/test/resources/expectedOutput/swagger.yaml
@@ -364,6 +364,47 @@ paths:
       - petstore_auth:
         - "write:pets"
         - "read:pets"
+  /pet/{startId}:{endId}:
+    get:
+      tags:
+      - "pet"
+      summary: "Find pet(s) by ID"
+      description: "This is a contrived example of a path segment containing multiple path parameters, separated by a character which may be present in the path parameter template. You may think that it returns a range of pets from startId to endId, inclusive, but it doesn't."
+      operationId: "getPetsById"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "startId"
+        in: "path"
+        description: "start ID of pets that needs to be fetched"
+        required: true
+        type: "integer"
+        maximum: 5.0
+        minimum: 1.0
+        format: "int64"
+      - name: "endId"
+        in: "path"
+        description: "end ID of pets that needs to be fetched"
+        required: true
+        type: "integer"
+        maximum: 5.0
+        minimum: 1.0
+        format: "int64"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Pet"
+        400:
+          description: "Invalid ID supplied"
+        404:
+          description: "Pet not found"
+      security:
+      - api_key: []
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
   /pet/{petId}:
     get:
       tags:
@@ -383,7 +424,7 @@ paths:
         type: "integer"
         maximum: 5.0
         minimum: 1.0
-        pattern: " [0-9]"
+        pattern: "[0-9]"
         format: "int64"
       responses:
         200:

--- a/src/test/resources/sample.html
+++ b/src/test/resources/sample.html
@@ -598,7 +598,7 @@ Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 
     <th>petName</th>
     <td>path</td>
     <td>yes</td>
-    <td>petName</td>
+    <td>petName (**Pattern**: `[^/]*`)</td>
     <td> - </td>
 
     
@@ -1679,7 +1679,7 @@ This is a contrived example of a path segment containing multiple path parameter
     <th>startId</th>
     <td>path</td>
     <td>yes</td>
-    <td>start ID of pets that need to be fetched (**Pattern**: `[0-9]`)</td>
+    <td>start ID of pets that need to be fetched (**Pattern**: `[0-9]{1,2}`)</td>
     <td> - </td>
 
     
@@ -1692,7 +1692,7 @@ This is a contrived example of a path segment containing multiple path parameter
     <th>endId</th>
     <td>path</td>
     <td>yes</td>
-    <td>end ID of pets that need to be fetched (**Pattern**: `[0-9]`)</td>
+    <td>end ID of pets that need to be fetched (**Pattern**: `[0-9]{1,2}`)</td>
     <td> - </td>
 
     

--- a/src/test/resources/sample.html
+++ b/src/test/resources/sample.html
@@ -1163,7 +1163,7 @@ Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API erro
     <th>petId</th>
     <td>path</td>
     <td>yes</td>
-    <td>ID of pet that needs to be fetched (**Pattern**: ` [0-9]`)</td>
+    <td>ID of pet that needs to be fetched (**Pattern**: `[0-9]`)</td>
     <td> - </td>
 
     
@@ -1613,6 +1613,112 @@ Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API erro
 | Status Code | Reason      | Response Model |
 |-------------|-------------|----------------|
 | 405    | Invalid input |  - |
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+## /pet/{startId}:{endId}
+
+
+### GET
+
+<a id="getPetsById">Find pet(s) by ID</a>
+
+This is a contrived example of a path segment containing multiple path parameters, separated by a character which may be present in the path parameter template. You may think that it returns a range of pets from startId to endId, inclusive, but it doesn&#x27;t.
+
+
+
+
+#### Security
+
+
+
+
+* api_key
+
+
+
+
+* petstore_auth
+   * write:pets
+   * read:pets
+
+
+
+
+#### Request
+
+
+
+##### Parameters
+
+<table border="1">
+    <tr>
+        <th>Name</th>
+        <th>Located in</th>
+        <th>Required</th>
+        <th>Description</th>
+        <th>Default</th>
+        <th>Schema</th>
+    </tr>
+
+
+
+<tr>
+    <th>startId</th>
+    <td>path</td>
+    <td>yes</td>
+    <td>start ID of pets that need to be fetched (**Pattern**: `[0-9]`)</td>
+    <td> - </td>
+
+    
+            <td>integer (int64)</td>
+    
+
+</tr>
+
+<tr>
+    <th>endId</th>
+    <td>path</td>
+    <td>yes</td>
+    <td>end ID of pets that need to be fetched (**Pattern**: `[0-9]`)</td>
+    <td> - </td>
+
+    
+            <td>integer (int64)</td>
+    
+
+</tr>
+
+
+</table>
+
+
+
+#### Response
+
+**Content-Type: ** application/xml, application/json
+
+
+| Status Code | Reason      | Response Model |
+|-------------|-------------|----------------|
+| 200    | successful operation | <a href="#/definitions/Pet">Pet</a>|
+| 400    | Invalid ID supplied |  - |
+| 404    | Pet not found |  - |
+
+
+
 
 
 


### PR DESCRIPTION
Fixes #304 

This pull request prefers the path-parsing part of swagger-jaxrs directly in order to properly parse path parts containing a plurality of path parameter templates or characters that would probably perplex the parser.

It also makes proper the path parameter pattern production problem
`/{petId : [0-9]}` -> " [0-9]"
(any whitespace between the colon and the regular expression is ignored: https://jsr311.java.net/nonav/javadoc/javax/ws/rs/Path.html#value())