### PR TITLE
Update reflections to 0.9.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <jettison.version>1.3.3</jettison.version>
         <json-unit.version>1.6.1</json-unit.version>
         <commons-io.version>2.0.1</commons-io.version>
-        <reflections.version>0.9.9-RC2</reflections.version>
+        <reflections.version>0.9.10</reflections.version>
         <maven-testing-harness.version>1.3</maven-testing-harness.version>
         <springframework.version>4.0.5.RELEASE</springframework.version>
     </properties>


### PR DESCRIPTION
Previous version die if during reflection inspection some class uses non-on-classpath classes, and the reported error is not helpful at all. This version handle errors nicely and allows the plugin to generate the doc just showing a warning. Thanks!