### PR TITLE
Handle generic values in BeanParms

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/jaxrs/BeanParamInjectParamExtention.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/jaxrs/BeanParamInjectParamExtention.java
@@ -126,11 +126,11 @@ public class BeanParamInjectParamExtention extends AbstractSwaggerExtension {
 
     private Type extractType(AccessibleObject accessibleObject, Type defaulType) {
         if (accessibleObject instanceof Field) {
-            return ((Field) accessibleObject).getType();
+            return ((Field) accessibleObject).getGenericType();
         } else if (accessibleObject instanceof Method) {
             Method method = (Method) accessibleObject;
-            if (method.getParameterTypes().length == 1) {
-                return method.getParameterTypes()[0];
+            if (method.getGenericParameterTypes().length == 1) {
+                return method.getGenericParameterTypes()[0];
             }
         }
         return defaulType;

--- a/src/test/java/com/wordnik/jaxrs/MyBean.java
+++ b/src/test/java/com/wordnik/jaxrs/MyBean.java
@@ -2,9 +2,12 @@ package com.wordnik.jaxrs;
 
 import io.swagger.annotations.ApiParam;
 
+import java.util.List;
+
 import javax.ws.rs.FormParam;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
 
 /**
  * @author chekong on 15/5/9.
@@ -28,6 +31,9 @@ public class MyBean extends MyParentBean {
 
     @HeaderParam("intValue")
     private int intValue;
+
+    @QueryParam(value = "listValue")
+    private List<String> listValue;
 
     public String getMyheader() {
         return myHeader;
@@ -69,6 +75,14 @@ public class MyBean extends MyParentBean {
         this.intValue = intValue;
     }
 
+    public List<String> getListValue() {
+        return listValue;
+    }
+
+    public void setListValue(List<String> listValue) {
+        this.listValue = listValue;
+    }
+
     @HeaderParam("myHeaderOnMethod")
     @ApiParam(value = "Header annotated on method", required = false)
     public void setMyheadronmethod(String myheadronmethod) {
@@ -77,5 +91,11 @@ public class MyBean extends MyParentBean {
     @HeaderParam("myLongHeaderOnMethod")
     @ApiParam(value = "Long header annotated on method", required = false)
     public void setMyintheaderonmethod(long mylongheaderonmethod) {
+    }
+
+    @QueryParam("genericListQueryParamOnMethod")
+    @ApiParam(value = "Generic List QueryParam on a method")
+    public void setFooValue(List<String> fooish) {
+
     }
 }

--- a/src/test/resources/expectedOutput/swagger-with-converter.json
+++ b/src/test/resources/expectedOutput/swagger-with-converter.json
@@ -717,6 +717,16 @@
             "format": "int32"
           },
           {
+            "name": "listValue",
+            "in": "query",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
             "name": "myParentHeader",
             "in": "header",
             "description": "Header from parent",
@@ -740,6 +750,17 @@
             "type": "integer",
             "default": "",
             "format": "int64"
+          },
+          {
+            "name": "genericListQueryParamOnMethod",
+            "in": "query",
+            "description": "Generic List QueryParam on a method",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
           }
         ],
         "responses": {
@@ -853,6 +874,16 @@
             "format": "int32"
           },
           {
+            "name": "listValue",
+            "in": "query",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
             "name": "myParentHeader",
             "in": "header",
             "description": "Header from parent",
@@ -876,6 +907,17 @@
             "type": "integer",
             "default": "",
             "format": "int64"
+          },
+          {
+            "name": "genericListQueryParamOnMethod",
+            "in": "query",
+            "description": "Generic List QueryParam on a method",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
           }
         ],
         "responses": {

--- a/src/test/resources/expectedOutput/swagger-with-converter.yaml
+++ b/src/test/resources/expectedOutput/swagger-with-converter.yaml
@@ -484,6 +484,13 @@ paths:
         type: "integer"
         default: ""
         format: "int32"
+      - name: "listValue"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
       - name: "myParentHeader"
         in: "header"
         description: "Header from parent"
@@ -503,6 +510,14 @@ paths:
         type: "integer"
         default: ""
         format: "int64"
+      - name: "genericListQueryParamOnMethod"
+        in: "query"
+        description: "Generic List QueryParam on a method"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
       responses:
         405:
           description: "Invalid input"
@@ -580,6 +595,13 @@ paths:
         type: "integer"
         default: ""
         format: "int32"
+      - name: "listValue"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
       - name: "myParentHeader"
         in: "header"
         description: "Header from parent"
@@ -599,6 +621,14 @@ paths:
         type: "integer"
         default: ""
         format: "int64"
+      - name: "genericListQueryParamOnMethod"
+        in: "query"
+        description: "Generic List QueryParam on a method"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
       responses:
         405:
           description: "Invalid input"

--- a/src/test/resources/expectedOutput/swagger.json
+++ b/src/test/resources/expectedOutput/swagger.json
@@ -720,6 +720,16 @@
             "format": "int32"
           },
           {
+            "name": "listValue",
+            "in": "query",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
             "name": "myParentHeader",
             "in": "header",
             "description": "Header from parent",
@@ -743,6 +753,17 @@
             "type": "integer",
             "default": "",
             "format": "int64"
+          },
+          {
+            "name": "genericListQueryParamOnMethod",
+            "in": "query",
+            "description": "Generic List QueryParam on a method",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
           }
         ],
         "responses": {
@@ -859,6 +880,16 @@
             "format": "int32"
           },
           {
+            "name": "listValue",
+            "in": "query",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
             "name": "myParentHeader",
             "in": "header",
             "description": "Header from parent",
@@ -882,6 +913,17 @@
             "type": "integer",
             "default": "",
             "format": "int64"
+          },
+          {
+            "name": "genericListQueryParamOnMethod",
+            "in": "query",
+            "description": "Generic List QueryParam on a method",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
           }
         ],
         "responses": {

--- a/src/test/resources/expectedOutput/swagger.yaml
+++ b/src/test/resources/expectedOutput/swagger.yaml
@@ -484,6 +484,13 @@ paths:
         type: "integer"
         default: ""
         format: "int32"
+      - name: "listValue"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
       - name: "myParentHeader"
         in: "header"
         description: "Header from parent"
@@ -503,6 +510,14 @@ paths:
         type: "integer"
         default: ""
         format: "int64"
+      - name: "genericListQueryParamOnMethod"
+        in: "query"
+        description: "Generic List QueryParam on a method"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
       responses:
         405:
           description: "Invalid input"
@@ -580,6 +595,13 @@ paths:
         type: "integer"
         default: ""
         format: "int32"
+      - name: "listValue"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
       - name: "myParentHeader"
         in: "header"
         description: "Header from parent"
@@ -599,6 +621,14 @@ paths:
         type: "integer"
         default: ""
         format: "int64"
+      - name: "genericListQueryParamOnMethod"
+        in: "query"
+        description: "Generic List QueryParam on a method"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
       responses:
         405:
           description: "Invalid input"

--- a/src/test/resources/sample.html
+++ b/src/test/resources/sample.html
@@ -1301,6 +1301,19 @@ Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API erro
 </tr>
 
 <tr>
+    <th>listValue</th>
+    <td>query</td>
+    <td>no</td>
+    <td></td>
+    <td> - </td>
+
+    
+            <td>Array[string] (multi)</td>
+    
+
+</tr>
+
+<tr>
     <th>myParentHeader</th>
     <td>header</td>
     <td>no</td>
@@ -1336,6 +1349,19 @@ Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API erro
 
     <td>integer (int64)</td>
 
+
+</tr>
+
+<tr>
+    <th>genericListQueryParamOnMethod</th>
+    <td>query</td>
+    <td>no</td>
+    <td>Generic List QueryParam on a method</td>
+    <td> - </td>
+
+    
+            <td>Array[string] (multi)</td>
+    
 
 </tr>
 
@@ -1562,6 +1588,19 @@ Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API erro
 </tr>
 
 <tr>
+    <th>listValue</th>
+    <td>query</td>
+    <td>no</td>
+    <td></td>
+    <td> - </td>
+
+    
+            <td>Array[string] (multi)</td>
+    
+
+</tr>
+
+<tr>
     <th>myParentHeader</th>
     <td>header</td>
     <td>no</td>
@@ -1597,6 +1636,19 @@ Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API erro
 
     <td>integer (int64)</td>
 
+
+</tr>
+
+<tr>
+    <th>genericListQueryParamOnMethod</th>
+    <td>query</td>
+    <td>no</td>
+    <td>Generic List QueryParam on a method</td>
+    <td> - </td>
+
+    
+            <td>Array[string] (multi)</td>
+    
 
 </tr>
 


### PR DESCRIPTION
This fixes an issue where type information was being thrown away for
values that used generics. This would caused all types inside
containers to always be object, and would actually be invalid for
query params.

For example:

``` java
    @QueryParam(value = "listValue")
    private List<String> listValue;
```

inside a BeanaParam produced

``` json
{
  "name" : "listValue",
  "in" : "query",
  "required" : false,
  "type" : "array",
  "items" : {
    "type" : "object"
  },
  "collectionFormat" : "multi"
}
```

instead of the expected

``` json
{
  "name" : "listValue",
  "in" : "query",
  "required" : false,
  "type" : "array",
  "items" : {
    "type" : "string"
  },
  "collectionFormat" : "multi"
}
```
