### PR TITLE
BeanParam default values substitution fixed

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/jaxrs/BeanParamInjectParamExtention.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/jaxrs/BeanParamInjectParamExtention.java
@@ -5,6 +5,7 @@ import com.sun.jersey.core.header.FormDataContentDisposition;
 import io.swagger.annotations.ApiParam;
 import io.swagger.jaxrs.ext.AbstractSwaggerExtension;
 import io.swagger.jaxrs.ext.SwaggerExtension;
+import io.swagger.models.parameters.AbstractSerializableParameter;
 import io.swagger.models.parameters.Parameter;
 import io.swagger.models.parameters.SerializableParameter;
 import io.swagger.models.properties.PropertyBuilder;
@@ -76,6 +77,10 @@ public class BeanParamInjectParamExtention extends AbstractSwaggerExtension {
                     parameter.setDescription(param.value());
                     parameter.setRequired(param.required());
                     parameter.setAccess(param.access());
+
+                    if (parameter instanceof AbstractSerializableParameter) {
+                        ((AbstractSerializableParameter)parameter).setDefaultValue(param.defaultValue());
+                    }
 
                     AllowableValues allowableValues = AllowableValuesUtils.create(param.allowableValues());
                     if (allowableValues != null) {

--- a/src/main/java/com/github/kongchen/swagger/docgen/jaxrs/BeanParamInjectParamExtention.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/jaxrs/BeanParamInjectParamExtention.java
@@ -11,6 +11,7 @@ import io.swagger.models.parameters.SerializableParameter;
 import io.swagger.models.properties.PropertyBuilder;
 import io.swagger.util.AllowableValues;
 import io.swagger.util.AllowableValuesUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.TypeUtils;
 
 import javax.ws.rs.BeanParam;
@@ -78,7 +79,7 @@ public class BeanParamInjectParamExtention extends AbstractSwaggerExtension {
                     parameter.setRequired(param.required());
                     parameter.setAccess(param.access());
 
-                    if (parameter instanceof AbstractSerializableParameter) {
+                    if (parameter instanceof AbstractSerializableParameter && StringUtils.isNotEmpty(param.defaultValue())) {
                         ((AbstractSerializableParameter)parameter).setDefaultValue(param.defaultValue());
                     }
 

--- a/src/test/java/com/wordnik/jaxrs/MyBean.java
+++ b/src/test/java/com/wordnik/jaxrs/MyBean.java
@@ -15,7 +15,7 @@ public class MyBean extends MyParentBean {
     @PathParam("petId")
     private String petId;
 
-    @ApiParam(value = "Updated name of the pet", required = false)
+    @ApiParam(value = "Updated name of the pet", required = false, defaultValue = "defaultValue")
     @FormParam("name")
     private String name;
 

--- a/src/test/resources/expectedOutput/swagger-with-converter.json
+++ b/src/test/resources/expectedOutput/swagger-with-converter.json
@@ -691,7 +691,8 @@
             "in": "formData",
             "description": "Updated name of the pet",
             "required": false,
-            "type": "string"
+            "type": "string",
+            "default": "defaultValue"
           },
           {
             "name": "status",
@@ -827,7 +828,8 @@
             "in": "formData",
             "description": "Updated name of the pet",
             "required": false,
-            "type": "string"
+            "type": "string",
+            "default": "defaultValue"
           },
           {
             "name": "status",

--- a/src/test/resources/expectedOutput/swagger-with-converter.yaml
+++ b/src/test/resources/expectedOutput/swagger-with-converter.yaml
@@ -465,6 +465,7 @@ paths:
         description: "Updated name of the pet"
         required: false
         type: "string"
+        default: "defaultValue"
       - name: "status"
         in: "formData"
         description: "Updated status of the pet"
@@ -561,6 +562,7 @@ paths:
         description: "Updated name of the pet"
         required: false
         type: "string"
+        default: "defaultValue"
       - name: "status"
         in: "formData"
         description: "Updated status of the pet"

--- a/src/test/resources/expectedOutput/swagger.json
+++ b/src/test/resources/expectedOutput/swagger.json
@@ -691,7 +691,8 @@
             "in": "formData",
             "description": "Updated name of the pet",
             "required": false,
-            "type": "string"
+            "type": "string",
+            "default": "defaultValue"
           },
           {
             "name": "status",
@@ -830,7 +831,8 @@
             "in": "formData",
             "description": "Updated name of the pet",
             "required": false,
-            "type": "string"
+            "type": "string",
+            "default": "defaultValue"
           },
           {
             "name": "status",

--- a/src/test/resources/expectedOutput/swagger.yaml
+++ b/src/test/resources/expectedOutput/swagger.yaml
@@ -465,6 +465,7 @@ paths:
         description: "Updated name of the pet"
         required: false
         type: "string"
+        default: "defaultValue"
       - name: "status"
         in: "formData"
         description: "Updated status of the pet"
@@ -561,6 +562,7 @@ paths:
         description: "Updated name of the pet"
         required: false
         type: "string"
+        default: "defaultValue"
       - name: "status"
         in: "formData"
         description: "Updated status of the pet"


### PR DESCRIPTION
Hi!

I use swagger maven plugin in a project I am working on. I faced the following issue: parameters placed inside a bean annotated with BeanParam annotation lose their default values provided with defaultValue annotation field. That is why generated documentation lacks default parameter values.

During investigation of the code I found out that BeanParamInjectParamExtention skips default values of parameters declared within BeanParam annotated beans. So I introduced small fix for this.

Best regards, 
Stanislau