### PR TITLE
SpringMvcApiReader does not recognize GetMapping, PostMapping, etc.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <commons-io.version>2.0.1</commons-io.version>
         <reflections.version>0.9.10</reflections.version>
         <maven-testing-harness.version>1.3</maven-testing-harness.version>
-        <springframework.version>4.0.5.RELEASE</springframework.version>
+        <springframework.version>4.3.1.RELEASE</springframework.version>
         <commons-lang3.version>[3.4,4.0)</commons-lang3.version>
         <junit-addons.version>[1.4,2.0)</junit-addons.version>
     </properties>

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiReader.java
@@ -326,8 +326,8 @@ public class SpringMvcApiReader extends AbstractReader implements ClassSwaggerRe
     private Map<String, List<Method>> collectApisByRequestMapping(List<Method> methods) {
         Map<String, List<Method>> apiMethodMap = new HashMap<String, List<Method>>();
         for (Method method : methods) {
-            if (method.isAnnotationPresent(RequestMapping.class)) {
-                RequestMapping requestMapping = AnnotationUtils.findAnnotation(method, RequestMapping.class);
+            RequestMapping requestMapping = AnnotationUtils.findAnnotation(method, RequestMapping.class);
+            if (requestMapping != null) {
                 String path;
                 if (requestMapping.value().length != 0) {
                     path = generateFullPath(requestMapping.value()[0]);


### PR DESCRIPTION
SpringMvcApiReader does not recognize GetMapping, PostMapping, and other similar annotations.

These annotation have been added since 4.3. Spring's AnnotationUtils class properly recognizes these 'composed annotations'. 