### PR TITLE
Make sure classes inheriting annotations are processed last

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiSource.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiSource.java
@@ -11,7 +11,7 @@ import org.springframework.core.annotation.AnnotationUtils;
 import java.io.File;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -124,14 +124,20 @@ public class ApiSource {
     private List<String> modelConverters;
 
     public Set<Class<?>> getValidClasses(Class<? extends Annotation> clazz) {
-        Set<Class<?>> classes = new HashSet<Class<?>>();
+        Set<Class<?>> classes = new LinkedHashSet<Class<?>>();
         if (getLocations() == null) {
-            Set<Class<?>> c = new Reflections("").getTypesAnnotatedWith(clazz);
+            Set<Class<?>> c = new Reflections("").getTypesAnnotatedWith(clazz, true);
             classes.addAll(c);
+
+            Set<Class<?>> inherited = new Reflections("").getTypesAnnotatedWith(clazz);
+            classes.addAll(inherited);
         } else {
             for (String location : locations) {
-                Set<Class<?>> c = new Reflections(location).getTypesAnnotatedWith(clazz);
+                Set<Class<?>> c = new Reflections(location).getTypesAnnotatedWith(clazz, true);
                 classes.addAll(c);
+
+                Set<Class<?>> inherited = new Reflections(location).getTypesAnnotatedWith(clazz);
+                classes.addAll(inherited);
             }
         }
 


### PR DESCRIPTION
This ensures that classes implementing interfaces with annotations are overriding the information read from the interfaces, not the other way around.
