### PR TITLE
For Jaxrs, allow @SwaggerDefinition.tags to specify Tag descriptions …

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
@@ -1,10 +1,6 @@
 package com.github.kongchen.swagger.docgen.reader;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponses;
-import io.swagger.annotations.Authorization;
-import io.swagger.annotations.AuthorizationScope;
+import io.swagger.annotations.*;
 import io.swagger.converter.ModelConverters;
 import io.swagger.jaxrs.ext.SwaggerExtension;
 import io.swagger.jaxrs.ext.SwaggerExtensions;
@@ -20,6 +16,7 @@ import io.swagger.models.properties.MapProperty;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.RefProperty;
 import org.apache.maven.plugin.logging.Log;
+import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.AnnotationUtils;
@@ -131,9 +128,33 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
                 updateOperation(apiConsumes, apiProduces, tags, securities, operation);
                 updatePath(operationPath, httpMethod, operation);
             }
+            updateTagDescriptions();
         }
 
         return swagger;
+    }
+
+    private void updateTagDescriptions() {
+        HashMap<String, Tag> tags = new HashMap<String, Tag>();
+        for (Class<?> aClass: new Reflections("").getTypesAnnotatedWith(SwaggerDefinition.class)) {
+            SwaggerDefinition swaggerDefinition = AnnotationUtils.findAnnotation(aClass, SwaggerDefinition.class);
+
+            for (io.swagger.annotations.Tag tag : swaggerDefinition.tags()) {
+
+                String tagName = tag.name();
+                if (!tagName.isEmpty()) {
+                    tags.put(tag.name(), new Tag().name(tag.name()).description(tag.description()));
+                }
+            }
+        }
+        if (swagger.getTags() != null) {
+            for (Tag tag : swagger.getTags()) {
+                Tag rightTag = tags.get(tag.getName());
+                if (rightTag != null && rightTag.getDescription() != null) {
+                    tag.setDescription(rightTag.getDescription());
+                }
+            }
+        }
     }
 
     private void handleSubResource(String[] apiConsumes, String httpMethod, String[] apiProduces, Map<String, Tag> tags, Method method, String operationPath, Operation operation) {

--- a/src/test/java/com/wordnik/jaxrs/UserResource.java
+++ b/src/test/java/com/wordnik/jaxrs/UserResource.java
@@ -29,6 +29,7 @@ import io.swagger.annotations.Contact;
 import io.swagger.annotations.Info;
 import io.swagger.annotations.License;
 import io.swagger.annotations.SwaggerDefinition;
+import io.swagger.annotations.Tag;
 
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -50,10 +51,13 @@ import javax.ws.rs.core.Response;
                 termsOfService = "http://www.github.com/kongchen/swagger-maven-plugin",
                 contact = @Contact(name = "Kong Chen", email = "kongchen@gmail.com", url = "http://kongch.com"),
                 license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html")
-        )
+        ),
+        tags = { @Tag(name = "user", description = "Operations about user"),
+                 @Tag(name = "spurioustag", description = "Operations about something spurious")
+        }
 )
 @Path("/user")
-@Api(value = "/user", description = "Operations about user")
+@Api(value = "/user")
 @Produces({"application/json", "application/xml"})
 public class UserResource {
     static UserData userData = new UserData();


### PR DESCRIPTION
…when not using (deprecated) @Api.description

I did not find a means to generate any tag descriptions without using the default tag name/description mapping in @Api, which I would rather not use.

I'm not a swagger expert, but I think this default mapping behavior is rather dubious. I could not see another way to introduce descriptions without breaking this behavior, however.
