### PR TITLE
Change scope for junit-addons dependency to test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,11 +126,6 @@
             <artifactId>commons-lang3</artifactId>
             <version>${commons-lang3.version}</version>
         </dependency>
-        <dependency>
-            <groupId>junit-addons</groupId>
-            <artifactId>junit-addons</artifactId>
-            <version>${junit-addons.version}</version>
-        </dependency>
 
         <dependency>
             <groupId>javax.ws.rs</groupId>
@@ -209,6 +204,12 @@
             <artifactId>jettison</artifactId>
             <version>${jettison.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+           <groupId>junit-addons</groupId>
+            <artifactId>junit-addons</artifactId>
+            <version>${junit-addons.version}</version>
+	    <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
The junit-addons:junit-addons dependency is only used for testing purposes. Therefore we set the correct scope. With the default 'compile' scope it can cause dependency issues because build plugins do not follow Maven dependency management rules, AFAIK.

Signed-off-by: Andreas Häber <andreas.haber@intele.com>