### PR TITLE
Improved handling of multiple apiSources

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/AbstractDocumentSource.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/AbstractDocumentSource.java
@@ -123,7 +123,7 @@ public abstract class AbstractDocumentSource {
                 throw new GenerateException(String.format("Create Swagger-outputDirectory[%s] failed.", swaggerPath));
             }
         }
-        cleanupOlds(dir, outputFormats);
+
         if (fileName == null || "".equals(fileName.trim())) {
             fileName = "swagger";
         }
@@ -231,19 +231,6 @@ public abstract class AbstractDocumentSource {
                 this.typesToSkip.add(type);
             } catch (ClassNotFoundException e) {
                 throw new GenerateException(e);
-            }
-        }
-    }
-
-
-    private void cleanupOlds(File dir, String outputFormats) {
-        if (dir.listFiles() != null && outputFormats != null) {
-            for (String format : outputFormats.split(",")) {
-                for (File f : dir.listFiles()) {
-                    if (f.getName().endsWith(format.toLowerCase())) {
-                        f.delete();
-                    }
-                }
             }
         }
     }

--- a/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiDocumentMojo.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiDocumentMojo.java
@@ -118,7 +118,9 @@ public class ApiDocumentMojo extends AbstractMojo {
                     String outputFormats = apiSource.getOutputFormats();
                     if (outputFormats != null) {
                         for (String format : outputFormats.split(",")) {
-                            String classifier = new File(apiSource.getSwaggerDirectory()).getName();
+                            String classifier = (swaggerFileName.equals("swagger"))
+                                    ? getSwaggerDirectoryName(apiSource.getSwaggerDirectory())
+                                    : swaggerFileName;
                             File swaggerFile = new File(apiSource.getSwaggerDirectory(), swaggerFileName + "." + format.toLowerCase());
                             projectHelper.attachArtifact(project, format.toLowerCase(), classifier, swaggerFile);
                         }
@@ -182,5 +184,9 @@ public class ApiDocumentMojo extends AbstractMojo {
     
     private String getSwaggerFileName(String swaggerFileName) {
         return swaggerFileName == null || "".equals(swaggerFileName.trim()) ? "swagger" : swaggerFileName;
+    }
+
+    private String getSwaggerDirectoryName(String swaggerDirectory) {
+        return new File(swaggerDirectory).getName();
     }
 }

--- a/src/test/resources/expectedOutput/only-store-resource.yaml
+++ b/src/test/resources/expectedOutput/only-store-resource.yaml
@@ -1,0 +1,198 @@
+---
+swagger: "2.0"
+info:
+  version: "1"
+  title: "Test Multiple ApiSources With Different Names 2"
+  description: "Only Store Resource"
+tags:
+- name: "store"
+schemes:
+- "http"
+- "https"
+paths:
+  /store/order:
+    post:
+      tags:
+      - "store"
+      summary: "Place an order for a pet"
+      description: ""
+      operationId: "placeOrder"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "order placed for purchasing the pet"
+        required: true
+        schema:
+          $ref: "#/definitions/Order"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Order"
+        400:
+          description: "Invalid Order"
+  /store/order/{orderId}:
+    get:
+      tags:
+      - "store"
+      summary: "Find purchase order by ID"
+      description: "For valid response try integer IDs with value <= 5 or > 10. Other\
+        \ values will generated exceptions"
+      operationId: "getOrderById"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - name: "orderId"
+        in: "path"
+        description: "ID of pet that needs to be fetched"
+        required: true
+        type: "string"
+        maximum: 5
+        minimum: 1
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Order"
+        400:
+          description: "Invalid ID supplied"
+        404:
+          description: "Order not found"
+    delete:
+      tags:
+      - "store"
+      summary: "Delete purchase order by ID"
+      description: "For valid response try integer IDs with value < 1000. Anything\
+        \ above 1000 or nonintegers will generate API errors"
+      operationId: "deleteOrder"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - name: "orderId"
+        in: "path"
+        description: "ID of the order that needs to be deleted"
+        required: true
+        type: "string"
+        minimum: 1
+      responses:
+        400:
+          description: "Invalid ID supplied"
+        404:
+          description: "Order not found"
+  /store/orders/{orderIds}:
+    get:
+      tags:
+      - "store"
+      summary: "Find multiple purchase orders by IDs"
+      description: "For valid response try integer IDs with value <= 5 or > 10. Other\
+        \ values will generated exceptions"
+      operationId: "getOrdersById"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - name: "orderIds"
+        in: "path"
+        description: "IDs of pets that needs to be fetched"
+        required: true
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "csv"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Order"
+        400:
+          description: "Invalid ID supplied"
+        404:
+          description: "Order not found"
+  /store/pingGet:
+    get:
+      tags:
+      - "store"
+      summary: "Simple ping endpoint"
+      description: ""
+      operationId: "pingGet"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters: []
+      responses:
+        200:
+          description: "Successful request - see response for 'pong'"
+          schema:
+            type: "string"
+  /store/pingPost:
+    post:
+      tags:
+      - "store"
+      summary: "Simple ping endpoint"
+      description: ""
+      operationId: "pingPost"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters: []
+      responses:
+        200:
+          description: "Successful request - see response for 'pong'"
+          schema:
+            type: "string"
+  /store/pingPut:
+    put:
+      tags:
+      - "store"
+      summary: "Simple ping endpoint"
+      description: ""
+      operationId: "pingPut"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters: []
+      responses:
+        200:
+          description: "Successful request - see response for 'pong'"
+          schema:
+            type: "string"
+definitions:
+  Order:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+      petId:
+        type: "integer"
+        format: "int64"
+      quantity:
+        type: "integer"
+        format: "int32"
+      shipDate:
+        type: "string"
+        format: "date-time"
+      status:
+        type: "string"
+        description: "Order Status"
+        enum:
+        - "placed"
+        - "approved"
+        - "delivered"
+      complete:
+        type: "boolean"
+      optionalStatus:
+        type: "string"
+      internalThing:
+        type: "string"
+      anotherInternalThing:
+        type: "string"
+    xml:
+      name: "Order"

--- a/src/test/resources/expectedOutput/only-user-resource.json
+++ b/src/test/resources/expectedOutput/only-user-resource.json
@@ -1,0 +1,262 @@
+{
+  "swagger" : "2.0",
+  "info" : {
+    "version" : "1",
+    "title" : "Test Multiple ApiSources With Different Names 1"
+  },
+  "host" : "www.example.com:8080",
+  "basePath" : "/api",
+  "tags" : [ {
+    "name" : "user",
+    "description" : "Operations about user"
+  } ],
+  "schemes" : [ "http", "https" ],
+  "paths" : {
+    "/user" : {
+      "post" : {
+        "tags" : [ "user" ],
+        "summary" : "Create user",
+        "description" : "This can only be done by the logged in user.",
+        "operationId" : "createUser",
+        "produces" : [ "application/json", "application/xml" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "body",
+          "description" : "Created user object",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/definitions/User"
+          }
+        } ],
+        "responses" : {
+          "default" : {
+            "description" : "successful operation"
+          }
+        }
+      }
+    },
+    "/user/createWithArray" : {
+      "post" : {
+        "tags" : [ "user" ],
+        "summary" : "Creates list of users with given input array",
+        "description" : "",
+        "operationId" : "createUsersWithArrayInput",
+        "produces" : [ "application/json", "application/xml" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "body",
+          "description" : "List of user object",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/definitions/User"
+            }
+          }
+        } ],
+        "responses" : {
+          "default" : {
+            "description" : "successful operation"
+          }
+        }
+      }
+    },
+    "/user/createWithList" : {
+      "post" : {
+        "tags" : [ "user" ],
+        "summary" : "Creates list of users with given input array",
+        "description" : "",
+        "operationId" : "createUsersWithListInput",
+        "produces" : [ "application/json", "application/xml" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "body",
+          "description" : "List of user object",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/definitions/User"
+            }
+          }
+        } ],
+        "responses" : {
+          "default" : {
+            "description" : "successful operation"
+          }
+        }
+      }
+    },
+    "/user/login" : {
+      "get" : {
+        "tags" : [ "user" ],
+        "summary" : "Logs user into the system",
+        "description" : "",
+        "operationId" : "loginUser",
+        "produces" : [ "application/json", "application/xml" ],
+        "parameters" : [ {
+          "name" : "username",
+          "in" : "query",
+          "description" : "The user name for login",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "password",
+          "in" : "query",
+          "description" : "The password for login in clear text",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          "400" : {
+            "description" : "Invalid username/password supplied"
+          }
+        }
+      }
+    },
+    "/user/logout" : {
+      "get" : {
+        "tags" : [ "user" ],
+        "summary" : "Logs out current logged in user session",
+        "description" : "",
+        "operationId" : "logoutUser",
+        "produces" : [ "application/json", "application/xml" ],
+        "responses" : {
+          "default" : {
+            "description" : "successful operation"
+          }
+        }
+      }
+    },
+    "/user/{username}" : {
+      "get" : {
+        "tags" : [ "user" ],
+        "summary" : "Get user by user name",
+        "description" : "",
+        "operationId" : "getUserByName",
+        "produces" : [ "application/json", "application/xml" ],
+        "parameters" : [ {
+          "name" : "username",
+          "in" : "path",
+          "description" : "The name that needs to be fetched. Use user1 for testing. ",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/User"
+            }
+          },
+          "400" : {
+            "description" : "Invalid username supplied"
+          },
+          "404" : {
+            "description" : "User not found"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "user" ],
+        "summary" : "Updated user",
+        "description" : "This can only be done by the logged in user.",
+        "operationId" : "updateUser",
+        "produces" : [ "application/json", "application/xml" ],
+        "parameters" : [ {
+          "name" : "username",
+          "in" : "path",
+          "description" : "name that need to be deleted",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "body",
+          "description" : "Updated user object",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/definitions/User"
+          }
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid user supplied"
+          },
+          "404" : {
+            "description" : "User not found"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "user" ],
+        "summary" : "Delete user",
+        "description" : "This can only be done by the logged in user.",
+        "operationId" : "deleteUser",
+        "produces" : [ "application/json", "application/xml" ],
+        "parameters" : [ {
+          "name" : "username",
+          "in" : "path",
+          "description" : "The name that needs to be deleted",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Invalid username supplied"
+          },
+          "404" : {
+            "description" : "User not found"
+          }
+        }
+      }
+    }
+  },
+  "definitions" : {
+    "User" : {
+      "type" : "object",
+      "properties" : {
+        "id" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "username" : {
+          "type" : "string"
+        },
+        "firstName" : {
+          "type" : "string"
+        },
+        "lastName" : {
+          "type" : "string"
+        },
+        "nickName" : {
+          "type" : "string",
+          "example" : "\"Bob\""
+        },
+        "email" : {
+          "type" : "string"
+        },
+        "password" : {
+          "type" : "string"
+        },
+        "phone" : {
+          "type" : "string"
+        },
+        "userStatus" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : 2,
+          "description" : "User Status"
+        }
+      },
+      "xml" : {
+        "name" : "User"
+      }
+    }
+  }
+}

--- a/src/test/resources/plugin-config-multiple-api-sources.xml
+++ b/src/test/resources/plugin-config-multiple-api-sources.xml
@@ -1,0 +1,97 @@
+<project>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.kongchen</groupId>
+                <artifactId>swagger-maven-plugin</artifactId>
+                <version>3.0-M2-SNAPSHOT</version>
+                <configuration>
+                    <apiSources>
+                        <apiSource>
+                            <springmvc>false</springmvc>
+                            <locations>
+                                <location>com.wordnik.jaxrs.UserResource</location>
+                            </locations>
+                            <schemes>
+                                <scheme>http</scheme>
+                                <scheme>https</scheme>
+                            </schemes>
+                            <info>
+                                <title>Test Multiple ApiSources With Different Names 1</title>
+                                <version>1</version>
+                                <description>Only User Resource</description>
+                            </info>
+                            <attachSwaggerArtifact>true</attachSwaggerArtifact>
+                            <swaggerFileName>user</swaggerFileName>
+                            <outputFormats>json</outputFormats>
+                            <swaggerDirectory>${basedir}/generated/swagger-ui</swaggerDirectory>
+                        </apiSource>
+                        <apiSource>
+                            <springmvc>false</springmvc>
+                            <locations>
+                                <location>com.wordnik.jaxrs.PetStoreResource</location>
+                            </locations>
+                            <schemes>
+                                <scheme>http</scheme>
+                                <scheme>https</scheme>
+                            </schemes>
+                            <info>
+                                <title>Test Multiple ApiSources With Different Names 2</title>
+                                <version>1</version>
+                                <description>Only Store Resource</description>
+                            </info>
+                            <attachSwaggerArtifact>true</attachSwaggerArtifact>
+                            <swaggerFileName>store</swaggerFileName>
+                            <outputFormats>yaml</outputFormats>
+                            <swaggerDirectory>${basedir}/generated/swagger-ui</swaggerDirectory>
+                        </apiSource>
+                        <apiSource>
+                            <springmvc>false</springmvc>
+                            <locations>
+                                <location>com.wordnik.jaxrs</location>
+                            </locations>
+                            <schemes>
+                                <scheme>http</scheme>
+                                <scheme>https</scheme>
+                            </schemes>
+                            <securityDefinitions>
+                                <securityDefinition>
+                                    <name>basicAuth</name>
+                                    <type>basic</type>
+                                </securityDefinition>
+                                <securityDefinition>
+                                    <json>/securityDefinition.json</json>
+                                </securityDefinition>
+                            </securityDefinitions>
+                            <!-- Support classpath or file absolute path here.
+                            1) classpath e.g: "classpath:/markdown.hbs", "classpath:/templates/hello.html"
+                            2) file e.g: "${basedir}/src/main/resources/markdown.hbs",
+                                "${basedir}/src/main/resources/template/hello.html" -->
+                            <templatePath>classpath:/templates/strapdown.html.hbs</templatePath>
+                            <outputPath>${basedir}/generated/document.html</outputPath>
+                            <outputFormats>json</outputFormats>
+                            <swaggerDirectory>${basedir}/generated/swagger-ui</swaggerDirectory>
+                            <swaggerApiReader>com.wordnik.jaxrs.VendorExtensionsJaxrsReader</swaggerApiReader>
+                            <attachSwaggerArtifact>true</attachSwaggerArtifact>
+                            <swaggerUIDocBasePath>http://www.example.com/restapi/doc</swaggerUIDocBasePath>
+                            <modelSubstitute>/override.map</modelSubstitute>
+                            <apiModelPropertyAccessExclusions>
+                                <apiModelPropertyAccessExclusion>secret-property</apiModelPropertyAccessExclusion>
+                                <apiModelPropertyAccessExclusion>another-secret-property</apiModelPropertyAccessExclusion>
+                                <apiModelPropertyAccessExclusion>exclude-when-jev-option-not-set</apiModelPropertyAccessExclusion>
+                            </apiModelPropertyAccessExclusions>
+                        </apiSource>
+                    </apiSources>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
## Changed:
* does not delete generated files [removed private method `cleanupOlds` in `AbstractDocumentSource.java`]
* use the custom `swaggerFileName` (when defined) for the artifacts, if not defined falls back to the `getSwaggerDirectory` name as before.

## Question:
I'm a bit unsure of the private method `cleanupOlds`'s purpose. All the tests pass even without it, so I felt pretty confident in removing it. But the passing tests might not be enough to prove its redundancy.