### PR TITLE
Improved handling of multiple apiSources with swaggerFileName defined

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/AbstractDocumentSource.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/AbstractDocumentSource.java
@@ -123,7 +123,7 @@ public abstract class AbstractDocumentSource {
                 throw new GenerateException(String.format("Create Swagger-outputDirectory[%s] failed.", swaggerPath));
             }
         }
-        cleanupOlds(dir, outputFormats);
+
         if (fileName == null || "".equals(fileName.trim())) {
             fileName = "swagger";
         }
@@ -231,19 +231,6 @@ public abstract class AbstractDocumentSource {
                 this.typesToSkip.add(type);
             } catch (ClassNotFoundException e) {
                 throw new GenerateException(e);
-            }
-        }
-    }
-
-
-    private void cleanupOlds(File dir, String outputFormats) {
-        if (dir.listFiles() != null && outputFormats != null) {
-            for (String format : outputFormats.split(",")) {
-                for (File f : dir.listFiles()) {
-                    if (f.getName().endsWith(format.toLowerCase())) {
-                        f.delete();
-                    }
-                }
             }
         }
     }

--- a/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiDocumentMojo.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiDocumentMojo.java
@@ -118,7 +118,9 @@ public class ApiDocumentMojo extends AbstractMojo {
                     String outputFormats = apiSource.getOutputFormats();
                     if (outputFormats != null) {
                         for (String format : outputFormats.split(",")) {
-                            String classifier = new File(apiSource.getSwaggerDirectory()).getName();
+                            String classifier = (swaggerFileName.equals("swagger"))
+                                    ? getSwaggerDirectoryName(apiSource.getSwaggerDirectory())
+                                    : swaggerFileName;
                             File swaggerFile = new File(apiSource.getSwaggerDirectory(), swaggerFileName + "." + format.toLowerCase());
                             projectHelper.attachArtifact(project, format.toLowerCase(), classifier, swaggerFile);
                         }
@@ -183,4 +185,9 @@ public class ApiDocumentMojo extends AbstractMojo {
     private String getSwaggerFileName(String swaggerFileName) {
         return swaggerFileName == null || "".equals(swaggerFileName.trim()) ? "swagger" : swaggerFileName;
     }
+
+    private String getSwaggerDirectoryName(String swaggerDirectory) {
+        return new File(swaggerDirectory).getName();
+    }
+
 }

--- a/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiDocumentMojo.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiDocumentMojo.java
@@ -118,7 +118,7 @@ public class ApiDocumentMojo extends AbstractMojo {
                     String outputFormats = apiSource.getOutputFormats();
                     if (outputFormats != null) {
                         for (String format : outputFormats.split(",")) {
-                            String classifier = (swaggerFileName.equals("swagger"))
+                            String classifier = swaggerFileName.equals("swagger")
                                     ? getSwaggerDirectoryName(apiSource.getSwaggerDirectory())
                                     : swaggerFileName;
                             File swaggerFile = new File(apiSource.getSwaggerDirectory(), swaggerFileName + "." + format.toLowerCase());

--- a/src/test/java/com/github/kongchen/smp/integration/SwaggerMavenPluginTest.java
+++ b/src/test/java/com/github/kongchen/smp/integration/SwaggerMavenPluginTest.java
@@ -222,6 +222,34 @@ public class SwaggerMavenPluginTest extends AbstractMojoTestCase {
         }
     }
 
+    @Test
+    public void testCustomModelConverterYaml() throws MojoFailureException, MojoExecutionException, IOException {
+        mojo.getApiSources().get(0).setModelConverters(ImmutableList.of(PetIdToStringModelConverter.class.getName()));
+
+        assertGeneratedSwaggerSpecYaml("This is a sample.", "/expectedOutput/swagger-with-converter.yaml");
+    }
+
+    @Test
+    public void testCustomModelConverterJson() throws MojoFailureException, MojoExecutionException, IOException {
+        mojo.getApiSources().get(0).setModelConverters(ImmutableList.of(PetIdToStringModelConverter.class.getName()));
+
+        executeAndAssertGeneratedSwaggerSpecJson("This is a sample.", "/expectedOutput/swagger-with-converter.json");
+    }
+
+    @Test
+    public void testMultipleApiSourcesWithDifferentArtifactName() throws Exception {
+        File testPom = new File(getBasedir(), "src/test/resources/plugin-config-multiple-api-sources.xml");
+        mojo = (ApiDocumentMojo) lookupMojo("generate", testPom);
+        mojo.execute();
+
+        assertTrue(new File(swaggerOutputDir, "custom-file-name-one.json").exists());
+        assertGeneratedSwaggerSpecJson("This is a sample.", "/expectedOutput/swagger.json", "custom-file-name-one.json");
+        assertTrue(new File(swaggerOutputDir, "custom-file-name-two.json").exists());
+        assertGeneratedSwaggerSpecJson("This is a sample.", "/expectedOutput/swagger.json", "custom-file-name-two.json");
+        assertTrue(new File(swaggerOutputDir, "swagger.json").exists());
+        assertGeneratedSwaggerSpecJson("This is a sample.", "/expectedOutput/swagger.json", "swagger.json");
+    }
+
     private void assertGeneratedSwaggerSpecJson(String description, String expectedOutput, String generatedFileName) throws IOException {
         JsonNode actualJson = mapper.readTree(new File(swaggerOutputDir, generatedFileName));
         JsonNode expectJson = mapper.readTree(this.getClass().getResourceAsStream(expectedOutput));
@@ -250,34 +278,6 @@ public class SwaggerMavenPluginTest extends AbstractMojoTestCase {
 
         changeDescription(expectJson, description);
         assertJsonEquals(expectJson, actualJson, Configuration.empty().when(IGNORING_ARRAY_ORDER));
-    }
-
-    @Test
-    public void testCustomModelConverterYaml() throws MojoFailureException, MojoExecutionException, IOException {
-        mojo.getApiSources().get(0).setModelConverters(ImmutableList.of(PetIdToStringModelConverter.class.getName()));
-
-        assertGeneratedSwaggerSpecYaml("This is a sample.", "/expectedOutput/swagger-with-converter.yaml");
-    }
-
-    @Test
-    public void testCustomModelConverterJson() throws MojoFailureException, MojoExecutionException, IOException {
-        mojo.getApiSources().get(0).setModelConverters(ImmutableList.of(PetIdToStringModelConverter.class.getName()));
-
-        executeAndAssertGeneratedSwaggerSpecJson("This is a sample.", "/expectedOutput/swagger-with-converter.json");
-    }
-
-    @Test
-    public void testMultipleApiSourcesWithDifferentArtifactName() throws Exception {
-        File testPom = new File(getBasedir(), "src/test/resources/plugin-config-multiple-api-sources.xml");
-        mojo = (ApiDocumentMojo) lookupMojo("generate", testPom);
-        mojo.execute();
-
-        assertTrue(new File(swaggerOutputDir, "custom-file-name-one.json").exists());
-        assertGeneratedSwaggerSpecJson("This is a sample.", "/expectedOutput/swagger.json", "custom-file-name-one.json");
-        assertTrue(new File(swaggerOutputDir, "custom-file-name-two.json").exists());
-        assertGeneratedSwaggerSpecJson("This is a sample.", "/expectedOutput/swagger.json", "custom-file-name-two.json");
-        assertTrue(new File(swaggerOutputDir, "swagger.json").exists());
-        assertGeneratedSwaggerSpecJson("This is a sample.", "/expectedOutput/swagger.json", "swagger.json");
     }
 
 }

--- a/src/test/resources/plugin-config-multiple-api-sources.xml
+++ b/src/test/resources/plugin-config-multiple-api-sources.xml
@@ -1,0 +1,133 @@
+<project>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.kongchen</groupId>
+                <artifactId>swagger-maven-plugin</artifactId>
+                <version>3.0-M2-SNAPSHOT</version>
+                <configuration>
+                    <apiSources>
+                        <apiSource>
+                            <springmvc>false</springmvc>
+                            <locations>
+                                <location>com.wordnik.jaxrs</location>
+                            </locations>
+                            <schemes>
+                                <scheme>http</scheme>
+                                <scheme>https</scheme>
+                            </schemes>
+                            <securityDefinitions>
+                                <securityDefinition>
+                                    <name>basicAuth</name>
+                                    <type>basic</type>
+                                </securityDefinition>
+                                <securityDefinition>
+                                    <json>/securityDefinition.json</json>
+                                </securityDefinition>
+                            </securityDefinitions>
+                            <!-- Support classpath or file absolute path here.
+                            1) classpath e.g: "classpath:/markdown.hbs", "classpath:/templates/hello.html"
+                            2) file e.g: "${basedir}/src/main/resources/markdown.hbs",
+                                "${basedir}/src/main/resources/template/hello.html" -->
+                            <templatePath>classpath:/templates/strapdown.html.hbs</templatePath>
+                            <outputPath>${basedir}/generated/document.html</outputPath>
+                            <swaggerFileName>custom-file-name-one</swaggerFileName>
+                            <outputFormats>json</outputFormats>
+                            <swaggerDirectory>${basedir}/generated/swagger-ui</swaggerDirectory>
+                            <swaggerApiReader>com.wordnik.jaxrs.VendorExtensionsJaxrsReader</swaggerApiReader>
+                            <attachSwaggerArtifact>true</attachSwaggerArtifact>
+                            <swaggerUIDocBasePath>http://www.example.com/restapi/doc</swaggerUIDocBasePath>
+                            <modelSubstitute>/override.map</modelSubstitute>
+                            <apiModelPropertyAccessExclusions>
+                                <apiModelPropertyAccessExclusion>secret-property</apiModelPropertyAccessExclusion>
+                                <apiModelPropertyAccessExclusion>another-secret-property</apiModelPropertyAccessExclusion>
+                                <apiModelPropertyAccessExclusion>exclude-when-jev-option-not-set</apiModelPropertyAccessExclusion>
+                            </apiModelPropertyAccessExclusions>
+                        </apiSource>
+                        <apiSource>
+                            <springmvc>false</springmvc>
+                            <locations>
+                                <location>com.wordnik.jaxrs</location>
+                            </locations>
+                            <schemes>
+                                <scheme>http</scheme>
+                                <scheme>https</scheme>
+                            </schemes>
+                            <securityDefinitions>
+                                <securityDefinition>
+                                    <name>basicAuth</name>
+                                    <type>basic</type>
+                                </securityDefinition>
+                                <securityDefinition>
+                                    <json>/securityDefinition.json</json>
+                                </securityDefinition>
+                            </securityDefinitions>
+                            <!-- Support classpath or file absolute path here.
+                            1) classpath e.g: "classpath:/markdown.hbs", "classpath:/templates/hello.html"
+                            2) file e.g: "${basedir}/src/main/resources/markdown.hbs",
+                                "${basedir}/src/main/resources/template/hello.html" -->
+                            <templatePath>classpath:/templates/strapdown.html.hbs</templatePath>
+                            <outputPath>${basedir}/generated/document.html</outputPath>
+                            <swaggerFileName>custom-file-name-two</swaggerFileName>
+                            <outputFormats>json</outputFormats>
+                            <swaggerDirectory>${basedir}/generated/swagger-ui</swaggerDirectory>
+                            <swaggerApiReader>com.wordnik.jaxrs.VendorExtensionsJaxrsReader</swaggerApiReader>
+                            <attachSwaggerArtifact>true</attachSwaggerArtifact>
+                            <swaggerUIDocBasePath>http://www.example.com/restapi/doc</swaggerUIDocBasePath>
+                            <modelSubstitute>/override.map</modelSubstitute>
+                            <apiModelPropertyAccessExclusions>
+                                <apiModelPropertyAccessExclusion>secret-property</apiModelPropertyAccessExclusion>
+                                <apiModelPropertyAccessExclusion>another-secret-property</apiModelPropertyAccessExclusion>
+                                <apiModelPropertyAccessExclusion>exclude-when-jev-option-not-set</apiModelPropertyAccessExclusion>
+                            </apiModelPropertyAccessExclusions>
+                        </apiSource>
+                        <apiSource>
+                            <springmvc>false</springmvc>
+                            <locations>
+                                <location>com.wordnik.jaxrs</location>
+                            </locations>
+                            <schemes>
+                                <scheme>http</scheme>
+                                <scheme>https</scheme>
+                            </schemes>
+                            <securityDefinitions>
+                                <securityDefinition>
+                                    <name>basicAuth</name>
+                                    <type>basic</type>
+                                </securityDefinition>
+                                <securityDefinition>
+                                    <json>/securityDefinition.json</json>
+                                </securityDefinition>
+                            </securityDefinitions>
+                            <!-- Support classpath or file absolute path here.
+                            1) classpath e.g: "classpath:/markdown.hbs", "classpath:/templates/hello.html"
+                            2) file e.g: "${basedir}/src/main/resources/markdown.hbs",
+                                "${basedir}/src/main/resources/template/hello.html" -->
+                            <templatePath>classpath:/templates/strapdown.html.hbs</templatePath>
+                            <outputPath>${basedir}/generated/document.html</outputPath>
+                            <outputFormats>json</outputFormats>
+                            <swaggerDirectory>${basedir}/generated/swagger-ui</swaggerDirectory>
+                            <swaggerApiReader>com.wordnik.jaxrs.VendorExtensionsJaxrsReader</swaggerApiReader>
+                            <attachSwaggerArtifact>true</attachSwaggerArtifact>
+                            <swaggerUIDocBasePath>http://www.example.com/restapi/doc</swaggerUIDocBasePath>
+                            <modelSubstitute>/override.map</modelSubstitute>
+                            <apiModelPropertyAccessExclusions>
+                                <apiModelPropertyAccessExclusion>secret-property</apiModelPropertyAccessExclusion>
+                                <apiModelPropertyAccessExclusion>another-secret-property</apiModelPropertyAccessExclusion>
+                                <apiModelPropertyAccessExclusion>exclude-when-jev-option-not-set</apiModelPropertyAccessExclusion>
+                            </apiModelPropertyAccessExclusions>
+                        </apiSource>
+                    </apiSources>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
## Changed:
* does not delete generated files [removed private method `cleanupOlds` in `AbstractDocumentSource.java`]
* use the custom `swaggerFileName` (when defined) for the artifacts, if not defined falls back to the `getSwaggerDirectory` name as before.

## Question:
I'm a bit unsure of the private method `cleanupOlds`'s purpose. All the tests pass even without it, so I felt pretty confident in removing it. But the passing tests might not be enough to prove its redundancy.


_Might be easier to go through each commit diff than checking the final diff_