### PR TITLE
Use project compile classpath in ApiSource#getValidClasses

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/AbstractDocumentSource.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/AbstractDocumentSource.java
@@ -28,6 +28,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
 
 import java.io.*;
 import java.lang.reflect.Constructor;
@@ -90,7 +91,7 @@ public abstract class AbstractDocumentSource {
     }
 
 
-    public abstract void loadDocuments() throws GenerateException;
+    public abstract void loadDocuments(MavenProject project) throws GenerateException;
 
     public void toSwaggerDocuments(String uiDocBasePath, String outputFormats, String encoding) throws GenerateException {
         toSwaggerDocuments(uiDocBasePath, outputFormats, null, encoding);

--- a/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiDocumentMojo.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiDocumentMojo.java
@@ -93,7 +93,7 @@ public class ApiDocumentMojo extends AbstractMojo {
                 documentSource.loadTypesToSkip();
                 documentSource.loadModelModifier();
                 documentSource.loadModelConverters();
-                documentSource.loadDocuments();
+                documentSource.loadDocuments(project);
                 if (apiSource.getOutputPath() != null) {
                     File outputDirectory = new File(apiSource.getOutputPath()).getParentFile();
                     if (outputDirectory != null && !outputDirectory.exists()) {

--- a/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/MavenDocumentSource.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/MavenDocumentSource.java
@@ -11,6 +11,7 @@ import io.swagger.core.filter.SwaggerSpecFilter;
 import io.swagger.models.auth.SecuritySchemeDefinition;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
 
 import java.util.HashMap;
 import java.util.List;
@@ -32,7 +33,7 @@ public class MavenDocumentSource extends AbstractDocumentSource {
     }
 
     @Override
-    public void loadDocuments() throws GenerateException {
+    public void loadDocuments(MavenProject project) throws GenerateException {
         if (apiSource.getSwaggerInternalFilter() != null) {
             try {
                 LOG.info("Setting filter configuration: " + apiSource.getSwaggerInternalFilter());

--- a/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/SpringMavenDocumentSource.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/SpringMavenDocumentSource.java
@@ -11,6 +11,7 @@ import io.swagger.core.filter.SwaggerSpecFilter;
 import io.swagger.models.auth.SecuritySchemeDefinition;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
 
 import java.util.HashMap;
 import java.util.List;
@@ -34,7 +35,7 @@ public class SpringMavenDocumentSource extends AbstractDocumentSource {
     }
 
     @Override
-    public void loadDocuments() throws GenerateException {
+    public void loadDocuments(MavenProject project) throws GenerateException {
         if (apiSource.getSwaggerInternalFilter() != null) {
             try {
                 LOG.info("Setting filter configuration: " + apiSource.getSwaggerInternalFilter());
@@ -44,8 +45,8 @@ public class SpringMavenDocumentSource extends AbstractDocumentSource {
             }
         }
 
-        swagger = resolveApiReader().read(apiSource.getValidClasses(Api.class));
-        
+        swagger = resolveApiReader().read(apiSource.getValidClasses(project, Api.class));
+
         if(apiSource.getSecurityDefinitions() != null) {
             for (SecurityDefinition sd : apiSource.getSecurityDefinitions()) {
                 for (Map.Entry<String, SecuritySchemeDefinition> entry : sd.getDefinitions().entrySet()) {


### PR DESCRIPTION
In case of maven multi modules, each modules publishing it's own API, the module build in second will also have the API of the module build in first.

Because in ApiSource#getValidClasses, new Reflections("").getTypesAnnotatedWith will finally use class loader in org.reflections.util.ClasspathHelper#contextClassLoader, which is the class loader of the mvn process. 

To solve this, please forward project compile class (available in ApiDocumentMojo#project.getCompileClasspathElements) to Reflections builder