### PR TITLE
Use fixed versions for commons-lang3 and junit-addons (latest release…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,8 @@
         <reflections.version>0.9.10</reflections.version>
         <maven-testing-harness.version>1.3</maven-testing-harness.version>
         <springframework.version>4.3.7.RELEASE</springframework.version>
-        <commons-lang3.version>[3.4,4.0)</commons-lang3.version>
-        <junit-addons.version>[1.4,2.0)</junit-addons.version>
+        <commons-lang3.version>3.5</commons-lang3.version>
+        <junit-addons.version>1.4</junit-addons.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
… versions present in search.maven.org)

Here's the issue I just filed for this : https://github.com/kongchen/swagger-maven-plugin/issues/469

The version ranges are bad for stability, and they're breaking our build with the way we have Artifactory setup. Let's just choose fixed versions; that plays much more nicely and we shouldn't be using SNAPSHOT versions for our release builds anyway!