### PR TITLE
Use Spring @RestController when @Api not found with unit test

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/SpringMavenDocumentSource.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/SpringMavenDocumentSource.java
@@ -4,6 +4,7 @@ import com.github.kongchen.swagger.docgen.AbstractDocumentSource;
 import com.github.kongchen.swagger.docgen.GenerateException;
 import com.github.kongchen.swagger.docgen.reader.ClassSwaggerReader;
 import com.github.kongchen.swagger.docgen.reader.SpringMvcApiReader;
+import com.google.common.collect.Sets;
 import io.swagger.annotations.Api;
 import io.swagger.config.FilterFactory;
 import io.swagger.core.filter.SpecFilter;
@@ -11,6 +12,7 @@ import io.swagger.core.filter.SwaggerSpecFilter;
 import io.swagger.models.auth.SecuritySchemeDefinition;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.HashMap;
 import java.util.List;
@@ -44,8 +46,9 @@ public class SpringMavenDocumentSource extends AbstractDocumentSource {
             }
         }
 
-        swagger = resolveApiReader().read(apiSource.getValidClasses(Api.class));
-        
+        Sets.SetView<Class<?>> validClasses = getValidClasses();
+        swagger = resolveApiReader().read(validClasses);
+
         if(apiSource.getSecurityDefinitions() != null) {
             for (SecurityDefinition sd : apiSource.getSecurityDefinitions()) {
                 for (Map.Entry<String, SecuritySchemeDefinition> entry : sd.getDefinitions().entrySet()) {
@@ -64,6 +67,13 @@ public class SpringMavenDocumentSource extends AbstractDocumentSource {
                     new HashMap<String, List<String>>(), new HashMap<String, String>(),
                     new HashMap<String, List<String>>());
         }
+    }
+
+    Sets.SetView<Class<?>> getValidClasses()
+    {
+        return Sets.union(
+            apiSource.getValidClasses(Api.class),
+            apiSource.getValidClasses(RestController.class));
     }
 
     private ClassSwaggerReader resolveApiReader() throws GenerateException {

--- a/src/test/java/com/github/kongchen/swagger/docgen/mavenplugin/SpringMavenDocumentSourceTest.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/mavenplugin/SpringMavenDocumentSourceTest.java
@@ -1,0 +1,43 @@
+package com.github.kongchen.swagger.docgen.mavenplugin;
+
+import com.google.common.collect.Sets;
+import io.swagger.annotations.Api;
+import java.util.Collections;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugin.logging.SystemStreamLog;
+import org.springframework.web.bind.annotation.RestController;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class SpringMavenDocumentSourceTest
+{
+    @Test
+    public void testGetValidClasses() throws Exception
+    {
+        Log log = new SystemStreamLog();
+
+        ApiSource apiSource = new ApiSource();
+        apiSource.setLocations(Collections.singletonList(this.getClass().getPackage().getName()));
+        apiSource.setSwaggerDirectory("./");
+
+        SpringMavenDocumentSource springMavenDocumentSource = new SpringMavenDocumentSource(apiSource, log, "UTF-8");
+
+        Sets.SetView<Class<?>> validClasses = springMavenDocumentSource.getValidClasses();
+
+        Assert.assertEquals(validClasses.size(), 2);
+        Assert.assertTrue(validClasses.contains(ExampleController1.class));
+        Assert.assertTrue(validClasses.contains(ExampleController2.class));
+    }
+
+
+    @RestController
+    private static class ExampleController1
+    {
+    }
+
+    @Api
+    @RestController
+    private static class ExampleController2
+    {
+    }
+}


### PR DESCRIPTION
Inspired by https://github.com/kongchen/swagger-maven-plugin/pull/477 I fixed the same issue and added a unit test as well.