### PR TITLE
Make plugin threadsafe again.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <jettison.version>1.3.3</jettison.version>
         <json-unit.version>1.17.0</json-unit.version>
         <commons-io.version>2.0.1</commons-io.version>
-        <reflections.version>0.9.10</reflections.version>
+        <reflections.version>0.9.9</reflections.version>
         <maven-testing-harness.version>1.3</maven-testing-harness.version>
         <springframework.version>4.3.7.RELEASE</springframework.version>
         <commons-lang3.version>3.5</commons-lang3.version>


### PR DESCRIPTION
Reverting dependency back to an older version of reflections to make the plugin thread-safe again. See issue: https://github.com/kongchen/swagger-maven-plugin/issues/483