### PR TITLE
Allow skipping generation via user property 'swagger.skip'

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Import the plugin in your project by adding following configuration in your `plu
 
 | **name** | **description** |
 |------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `skipSwaggerGeneration` | If `true`, swagger generation will be skipped. Default is `false`. |
+| `skipSwaggerGeneration` | If `true`, swagger generation will be skipped. Default is `false`. User property is `swagger.skip`. |
 | `apiSources` | List of `apiSource` elements. One `apiSource` can be considered as a version of APIs of your service. You can specify several `apiSource` elements, though generally one is enough. |
 
 # Configuration for `apiSource`

--- a/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiDocumentMojo.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiDocumentMojo.java
@@ -44,7 +44,7 @@ public class ApiDocumentMojo extends AbstractMojo {
     /**
      * A flag indicating if the generation should be skipped.
      */
-    @Parameter(defaultValue = "false")
+    @Parameter(property = "swagger.skip", defaultValue = "false")
     private boolean skipSwaggerGeneration;
     
     @Parameter(property="file.encoding")


### PR DESCRIPTION
This allows users of the `swagger-maven-plugin` to skip Swagger generation without the need to edit their `pom.xml`.

Name chosen for similarity with `checkstyle.skip`, `rat.skip`, `maven.test.skip`, etc.

Example usage (for projects using this plugin):

```
mvn -Dswagger.skip clean test
```