### PR TITLE
making sure the modelconverters are called with the parameterized type

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
@@ -377,59 +377,59 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
         return operation;
     }
 
-    private Class<?> convertToClass(Type type) {
-        Type typeToConvert = type;
-        if (type instanceof ParameterizedType) {
-            typeToConvert = ((ParameterizedType) type).getRawType();
-        }
-        try {
-            return Class.forName(getClassName(typeToConvert));
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-    }
+	private Class<?> convertToClass(Type type) {
+		Type typeToConvert = type;
+		if (type instanceof ParameterizedType) {
+			typeToConvert = ((ParameterizedType) type).getRawType();
+		}
+		try {
+			return Class.forName(getClassName(typeToConvert));
+		} catch (ClassNotFoundException e) {
+			throw new RuntimeException(e);
+		}
+	}
 
-    private static String getClassName(Type type) {
-        String fullName = type.toString();
-        if (fullName.startsWith(CLASS_NAME_PREFIX)) {
-            return fullName.substring(CLASS_NAME_PREFIX.length());
-        } else if (fullName.startsWith(INTERFACE_NAME_PREFIX)) {
-            return fullName.substring(INTERFACE_NAME_PREFIX.length());
-        }
-        return fullName;
-    }
+	private static String getClassName(Type type) {
+		String fullName = type.toString();
+		if (fullName.startsWith(CLASS_NAME_PREFIX)) {
+			return fullName.substring(CLASS_NAME_PREFIX.length());
+		} else if (fullName.startsWith(INTERFACE_NAME_PREFIX)) {
+			return fullName.substring(INTERFACE_NAME_PREFIX.length());
+		}
+		return fullName;
+	}
 
-    private Annotation[][] findParamAnnotations(Method method) {
-        Annotation[][] paramAnnotation = method.getParameterAnnotations();
+	private Annotation[][] findParamAnnotations(Method method) {
+		Annotation[][] paramAnnotation = method.getParameterAnnotations();
 
-        method = ReflectionUtils.getOverriddenMethod(method);
-        while(method != null) {
-            paramAnnotation = merge(paramAnnotation, method.getParameterAnnotations());
-            method = ReflectionUtils.getOverriddenMethod(method);
-        }
-        return paramAnnotation;
-    }
+		method = ReflectionUtils.getOverriddenMethod(method);
+		while(method != null) {
+			paramAnnotation = merge(paramAnnotation, method.getParameterAnnotations());
+			method = ReflectionUtils.getOverriddenMethod(method);
+		}
+		return paramAnnotation;
+	}
 
 
     private Annotation[][] merge(Annotation[][] paramAnnotation,
-            Annotation[][] superMethodParamAnnotations) {
-        Annotation[][] mergedAnnotations = new Annotation[paramAnnotation.length][];
+			Annotation[][] superMethodParamAnnotations) {
+    	Annotation[][] mergedAnnotations = new Annotation[paramAnnotation.length][];
 
-        for(int i=0; i<paramAnnotation.length; i++) {
-            mergedAnnotations[i] = merge(paramAnnotation[i], superMethodParamAnnotations[i]);
-        }
-        return mergedAnnotations;
-    }
+    	for(int i=0; i<paramAnnotation.length; i++) {
+    		mergedAnnotations[i] = merge(paramAnnotation[i], superMethodParamAnnotations[i]);
+    	}
+		return mergedAnnotations;
+	}
 
-    private Annotation[] merge(Annotation[] annotations,
-            Annotation[] annotations2) {
-        Set<Annotation> mergedAnnotations = new HashSet<Annotation>();
-        mergedAnnotations.addAll(Arrays.asList(annotations));
-        mergedAnnotations.addAll(Arrays.asList(annotations2));
-        return mergedAnnotations.toArray(new Annotation[0]);
-    }
+	private Annotation[] merge(Annotation[] annotations,
+			Annotation[] annotations2) {
+		Set<Annotation> mergedAnnotations = new HashSet<Annotation>();
+		mergedAnnotations.addAll(Arrays.asList(annotations));
+		mergedAnnotations.addAll(Arrays.asList(annotations2));
+		return mergedAnnotations.toArray(new Annotation[0]);
+	}
 
-    public String extractOperationMethod(ApiOperation apiOperation, Method method, Iterator<SwaggerExtension> chain) {
+	public String extractOperationMethod(ApiOperation apiOperation, Method method, Iterator<SwaggerExtension> chain) {
         if (!apiOperation.httpMethod().isEmpty()) {
             return apiOperation.httpMethod().toLowerCase();
         } else if (AnnotationUtils.findAnnotation(method, GET.class) != null) {

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
@@ -313,6 +313,10 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
                             .headers(defaultResponseHeaders));
                     swagger.model(key, models.get(key));
                 }
+                models = ModelConverters.getInstance().readAll(responseClass);
+                for (Map.Entry<String, Model> entry : models.entrySet()) {
+                    swagger.model(entry.getKey(), entry.getValue());
+                }
             }
         }
 

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
@@ -48,8 +48,8 @@ import java.util.Set;
 public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
     private static final Logger LOGGER = LoggerFactory.getLogger(JaxrsReader.class);
     private static final ResponseContainerConverter RESPONSE_CONTAINER_CONVERTER = new ResponseContainerConverter();
-	private static final String CLASS_NAME_PREFIX = "class ";
-	private static final String INTERFACE_NAME_PREFIX = "interface ";
+    private static final String CLASS_NAME_PREFIX = "class ";
+    private static final String INTERFACE_NAME_PREFIX = "interface ";
 
     public JaxrsReader(Swagger swagger, Log LOG) {
         super(swagger, LOG);
@@ -57,7 +57,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
 
     @Override
     public Swagger read(Set<Class<?>> classes) {
-		for (Class<?> cls : classes) {
+        for (Class<?> cls : classes) {
             read(cls);
         }
         return swagger;
@@ -67,7 +67,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
         return swagger;
     }
 
-	public Swagger read(Class<?> cls) {
+    public Swagger read(Class<?> cls) {
         return read(cls, "", null, false, new String[0], new String[0], new HashMap<String, Tag>(), new ArrayList<Parameter>());
     }
 
@@ -166,7 +166,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
     private void handleSubResource(String[] apiConsumes, String httpMethod, String[] apiProduces, Map<String, Tag> tags, Method method, String operationPath, Operation operation) {
         if (isSubResource(method)) {
             Class<?> responseClass = method.getReturnType();
-			read(responseClass, operationPath, httpMethod, true, apiConsumes, apiProduces, tags, operation.getParameters());
+            read(responseClass, operationPath, httpMethod, true, apiConsumes, apiProduces, tags, operation.getParameters());
         }
     }
 
@@ -222,7 +222,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
         String operationId = method.getName();
         String responseContainer = null;
 
-		Type responseClassType = null;
+        Type responseClassType = null;
         Map<String, Property> defaultResponseHeaders = null;
 
         if (apiOperation != null) {
@@ -248,7 +248,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
                 }
             }
 
-			if (!apiOperation.response().equals(Void.class) && !apiOperation.response().equals(void.class)) {
+            if (!apiOperation.response().equals(Void.class) && !apiOperation.response().equals(void.class)) {
                 responseClassType = apiOperation.response();
             }
             if (!apiOperation.responseContainer().isEmpty()) {
@@ -277,13 +277,13 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
         if (responseClassType == null) {
             // pick out response from method declaration
             LOGGER.debug("picking up response class from method " + method);
-			responseClassType = method.getGenericReturnType();
+            responseClassType = method.getGenericReturnType();
         }
         if ((responseClassType != null)
                 && !responseClassType.equals(Void.class)
-				&& !responseClassType.equals(void.class)
+                && !responseClassType.equals(void.class)
                 && !responseClassType.equals(javax.ws.rs.core.Response.class)
-				&& (AnnotationUtils.findAnnotation(convertToClass(responseClassType), Api.class) == null)) {
+                && (AnnotationUtils.findAnnotation(convertToClass(responseClassType), Api.class) == null)) {
             if (isPrimitive(responseClassType)) {
                 Property property = ModelConverters.getInstance().readAsProperty(responseClassType);
                 if (property != null) {
@@ -350,7 +350,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
         }
 
         // process parameters
-		Class<?>[] parameterTypes = method.getParameterTypes();
+        Class<?>[] parameterTypes = method.getParameterTypes();
         Type[] genericParameterTypes = method.getGenericParameterTypes();
         Annotation[][] paramAnnotations = findParamAnnotations(method);
 
@@ -377,59 +377,59 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
         return operation;
     }
 
-	private Class<?> convertToClass(Type type) {
-		Type typeToConvert = type;
-		if (type instanceof ParameterizedType) {
-			typeToConvert = ((ParameterizedType) type).getRawType();
-		}
-		try {
-			return Class.forName(getClassName(typeToConvert));
-		} catch (ClassNotFoundException e) {
-			throw new RuntimeException(e);
-		}
-	}
+    private Class<?> convertToClass(Type type) {
+        Type typeToConvert = type;
+        if (type instanceof ParameterizedType) {
+            typeToConvert = ((ParameterizedType) type).getRawType();
+        }
+        try {
+            return Class.forName(getClassName(typeToConvert));
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
-	private static String getClassName(Type type) {
-		String fullName = type.toString();
-		if (fullName.startsWith(CLASS_NAME_PREFIX)) {
-			return fullName.substring(CLASS_NAME_PREFIX.length());
-		} else if (fullName.startsWith(INTERFACE_NAME_PREFIX)) {
-			return fullName.substring(INTERFACE_NAME_PREFIX.length());
-		}
-		return fullName;
-	}
+    private static String getClassName(Type type) {
+        String fullName = type.toString();
+        if (fullName.startsWith(CLASS_NAME_PREFIX)) {
+            return fullName.substring(CLASS_NAME_PREFIX.length());
+        } else if (fullName.startsWith(INTERFACE_NAME_PREFIX)) {
+            return fullName.substring(INTERFACE_NAME_PREFIX.length());
+        }
+        return fullName;
+    }
 
-	private Annotation[][] findParamAnnotations(Method method) {
-		Annotation[][] paramAnnotation = method.getParameterAnnotations();
+    private Annotation[][] findParamAnnotations(Method method) {
+        Annotation[][] paramAnnotation = method.getParameterAnnotations();
 
-		method = ReflectionUtils.getOverriddenMethod(method);
-		while(method != null) {
-			paramAnnotation = merge(paramAnnotation, method.getParameterAnnotations());
-			method = ReflectionUtils.getOverriddenMethod(method);
-		}
-		return paramAnnotation;
-	}
+        method = ReflectionUtils.getOverriddenMethod(method);
+        while(method != null) {
+            paramAnnotation = merge(paramAnnotation, method.getParameterAnnotations());
+            method = ReflectionUtils.getOverriddenMethod(method);
+        }
+        return paramAnnotation;
+    }
 
 
     private Annotation[][] merge(Annotation[][] paramAnnotation,
-			Annotation[][] superMethodParamAnnotations) {
-    	Annotation[][] mergedAnnotations = new Annotation[paramAnnotation.length][];
+            Annotation[][] superMethodParamAnnotations) {
+        Annotation[][] mergedAnnotations = new Annotation[paramAnnotation.length][];
 
-    	for(int i=0; i<paramAnnotation.length; i++) {
-    		mergedAnnotations[i] = merge(paramAnnotation[i], superMethodParamAnnotations[i]);
-    	}
-		return mergedAnnotations;
-	}
+        for(int i=0; i<paramAnnotation.length; i++) {
+            mergedAnnotations[i] = merge(paramAnnotation[i], superMethodParamAnnotations[i]);
+        }
+        return mergedAnnotations;
+    }
 
-	private Annotation[] merge(Annotation[] annotations,
-			Annotation[] annotations2) {
-		Set<Annotation> mergedAnnotations = new HashSet<Annotation>();
-		mergedAnnotations.addAll(Arrays.asList(annotations));
-		mergedAnnotations.addAll(Arrays.asList(annotations2));
-		return mergedAnnotations.toArray(new Annotation[0]);
-	}
+    private Annotation[] merge(Annotation[] annotations,
+            Annotation[] annotations2) {
+        Set<Annotation> mergedAnnotations = new HashSet<Annotation>();
+        mergedAnnotations.addAll(Arrays.asList(annotations));
+        mergedAnnotations.addAll(Arrays.asList(annotations2));
+        return mergedAnnotations.toArray(new Annotation[0]);
+    }
 
-	public String extractOperationMethod(ApiOperation apiOperation, Method method, Iterator<SwaggerExtension> chain) {
+    public String extractOperationMethod(ApiOperation apiOperation, Method method, Iterator<SwaggerExtension> chain) {
         if (!apiOperation.httpMethod().isEmpty()) {
             return apiOperation.httpMethod().toLowerCase();
         } else if (AnnotationUtils.findAnnotation(method, GET.class) != null) {

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
@@ -34,6 +34,7 @@ import javax.ws.rs.Produces;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -47,6 +48,8 @@ import java.util.Set;
 public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
     private static final Logger LOGGER = LoggerFactory.getLogger(JaxrsReader.class);
     private static final ResponseContainerConverter RESPONSE_CONTAINER_CONVERTER = new ResponseContainerConverter();
+	private static final String CLASS_NAME_PREFIX = "class ";
+	private static final String INTERFACE_NAME_PREFIX = "interface ";
 
     public JaxrsReader(Swagger swagger, Log LOG) {
         super(swagger, LOG);
@@ -54,7 +57,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
 
     @Override
     public Swagger read(Set<Class<?>> classes) {
-        for (Class cls : classes) {
+		for (Class<?> cls : classes) {
             read(cls);
         }
         return swagger;
@@ -64,7 +67,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
         return swagger;
     }
 
-    public Swagger read(Class cls) {
+	public Swagger read(Class<?> cls) {
         return read(cls, "", null, false, new String[0], new String[0], new HashMap<String, Tag>(), new ArrayList<Parameter>());
     }
 
@@ -163,7 +166,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
     private void handleSubResource(String[] apiConsumes, String httpMethod, String[] apiProduces, Map<String, Tag> tags, Method method, String operationPath, Operation operation) {
         if (isSubResource(method)) {
             Class<?> responseClass = method.getReturnType();
-            Swagger subSwagger = read(responseClass, operationPath, httpMethod, true, apiConsumes, apiProduces, tags, operation.getParameters());
+			read(responseClass, operationPath, httpMethod, true, apiConsumes, apiProduces, tags, operation.getParameters());
         }
     }
 
@@ -219,7 +222,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
         String operationId = method.getName();
         String responseContainer = null;
 
-        Class<?> responseClass = null;
+		Type responseClassType = null;
         Map<String, Property> defaultResponseHeaders = null;
 
         if (apiOperation != null) {
@@ -245,8 +248,8 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
                 }
             }
 
-            if (!apiOperation.response().equals(Void.class)) {
-                responseClass = apiOperation.response();
+			if (!apiOperation.response().equals(Void.class) && !apiOperation.response().equals(void.class)) {
+                responseClassType = apiOperation.response();
             }
             if (!apiOperation.responseContainer().isEmpty()) {
                 responseContainer = apiOperation.responseContainer();
@@ -271,23 +274,18 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
         }
         operation.operationId(operationId);
 
-        if (responseClass == null) {
+        if (responseClassType == null) {
             // pick out response from method declaration
             LOGGER.debug("picking up response class from method " + method);
-            Type t = method.getGenericReturnType();
-            responseClass = method.getReturnType();
-            if (!responseClass.equals(Void.class) && !responseClass.equals(void.class)
-                    && (AnnotationUtils.findAnnotation(responseClass, Api.class) == null)) {
-                LOGGER.debug("reading model " + responseClass);
-                Map<String, Model> models = ModelConverters.getInstance().readAll(t);
-            }
+			responseClassType = method.getGenericReturnType();
         }
-        if ((responseClass != null)
-                && !responseClass.equals(Void.class)
-                && !responseClass.equals(javax.ws.rs.core.Response.class)
-                && (AnnotationUtils.findAnnotation(responseClass, Api.class) == null)) {
-            if (isPrimitive(responseClass)) {
-                Property property = ModelConverters.getInstance().readAsProperty(responseClass);
+        if ((responseClassType != null)
+                && !responseClassType.equals(Void.class)
+				&& !responseClassType.equals(void.class)
+                && !responseClassType.equals(javax.ws.rs.core.Response.class)
+				&& (AnnotationUtils.findAnnotation(convertToClass(responseClassType), Api.class) == null)) {
+            if (isPrimitive(responseClassType)) {
+                Property property = ModelConverters.getInstance().readAsProperty(responseClassType);
                 if (property != null) {
                     Property responseProperty = RESPONSE_CONTAINER_CONVERTER.withResponseContainer(responseContainer, property);
 
@@ -296,10 +294,10 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
                             .schema(responseProperty)
                             .headers(defaultResponseHeaders));
                 }
-            } else if (!responseClass.equals(Void.class) && !responseClass.equals(void.class)) {
-                Map<String, Model> models = ModelConverters.getInstance().read(responseClass);
+            } else if (!responseClassType.equals(Void.class) && !responseClassType.equals(void.class)) {
+                Map<String, Model> models = ModelConverters.getInstance().read(responseClassType);
                 if (models.isEmpty()) {
-                    Property p = ModelConverters.getInstance().readAsProperty(responseClass);
+                    Property p = ModelConverters.getInstance().readAsProperty(responseClassType);
                     operation.response(apiOperation.code(), new Response()
                             .description("successful operation")
                             .schema(p)
@@ -314,10 +312,6 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
                             .schema(responseProperty)
                             .headers(defaultResponseHeaders));
                     swagger.model(key, models.get(key));
-                }
-                models = ModelConverters.getInstance().readAll(responseClass);
-                for (Map.Entry<String, Model> entry : models.entrySet()) {
-                    swagger.model(entry.getKey(), entry.getValue());
                 }
             }
         }
@@ -352,7 +346,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
         }
 
         // process parameters
-        Class[] parameterTypes = method.getParameterTypes();
+		Class<?>[] parameterTypes = method.getParameterTypes();
         Type[] genericParameterTypes = method.getGenericParameterTypes();
         Annotation[][] paramAnnotations = findParamAnnotations(method);
 
@@ -379,9 +373,31 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
         return operation;
     }
 
+	private Class<?> convertToClass(Type type) {
+		Type typeToConvert = type;
+		if (type instanceof ParameterizedType) {
+			typeToConvert = ((ParameterizedType) type).getRawType();
+		}
+		try {
+			return Class.forName(getClassName(typeToConvert));
+		} catch (ClassNotFoundException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private static String getClassName(Type type) {
+		String fullName = type.toString();
+		if (fullName.startsWith(CLASS_NAME_PREFIX)) {
+			return fullName.substring(CLASS_NAME_PREFIX.length());
+		} else if (fullName.startsWith(INTERFACE_NAME_PREFIX)) {
+			return fullName.substring(INTERFACE_NAME_PREFIX.length());
+		}
+		return fullName;
+	}
+
 	private Annotation[][] findParamAnnotations(Method method) {
 		Annotation[][] paramAnnotation = method.getParameterAnnotations();
-		
+
 		method = ReflectionUtils.getOverriddenMethod(method);
 		while(method != null) {
 			paramAnnotation = merge(paramAnnotation, method.getParameterAnnotations());
@@ -394,7 +410,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
     private Annotation[][] merge(Annotation[][] paramAnnotation,
 			Annotation[][] superMethodParamAnnotations) {
     	Annotation[][] mergedAnnotations = new Annotation[paramAnnotation.length][];
-    	
+
     	for(int i=0; i<paramAnnotation.length; i++) {
     		mergedAnnotations[i] = merge(paramAnnotation[i], superMethodParamAnnotations[i]);
     	}

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
@@ -313,7 +313,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
                             .headers(defaultResponseHeaders));
                     swagger.model(key, models.get(key));
                 }
-                models = ModelConverters.getInstance().readAll(responseClass);
+				models = ModelConverters.getInstance().readAll(responseClassType);
                 for (Map.Entry<String, Model> entry : models.entrySet()) {
                     swagger.model(entry.getKey(), entry.getValue());
                 }

--- a/src/test/java/com/github/kongchen/smp/integration/SwaggerMavenPluginTest.java
+++ b/src/test/java/com/github/kongchen/smp/integration/SwaggerMavenPluginTest.java
@@ -43,7 +43,8 @@ public class SwaggerMavenPluginTest extends AbstractMojoTestCase {
     private ApiDocumentMojo mojo;
     private ObjectMapper mapper = new ObjectMapper();
 
-    @BeforeMethod
+    @Override
+	@BeforeMethod
     protected void setUp() throws Exception {
         super.setUp();
 

--- a/src/test/java/com/wordnik/jaxrs/PagedList.java
+++ b/src/test/java/com/wordnik/jaxrs/PagedList.java
@@ -1,0 +1,29 @@
+package com.wordnik.jaxrs;
+
+import java.util.List;
+
+public class PagedList<T> {
+
+	private int pageNumber;
+	private int totalItems;
+	private List<T> items;
+
+	public PagedList(int pageNumber, int totalItems, List<T> itemsOnPage) {
+		this.pageNumber = pageNumber;
+		this.totalItems = totalItems;
+		this.items = itemsOnPage;
+	}
+
+	public int getPageNumber() {
+		return pageNumber;
+	}
+
+	public int getTotalItems() {
+		return totalItems;
+	}
+
+	public List<T> getItems() {
+		return items;
+	}
+
+}

--- a/src/test/java/com/wordnik/jaxrs/PetResource.java
+++ b/src/test/java/com/wordnik/jaxrs/PetResource.java
@@ -34,6 +34,8 @@ import io.swagger.annotations.AuthorizationScope;
 import io.swagger.annotations.Extension;
 import io.swagger.annotations.ExtensionProperty;
 
+import java.util.List;
+
 import javax.ws.rs.BeanParam;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -179,6 +181,19 @@ public class PetResource {
             @ApiParam(value = "Tags to filter by", required = true, allowMultiple = true) @QueryParam("tags") String tags) {
         return Response.ok(petData.findPetByTags(tags)).build();
     }
+
+	@GET
+	@Path("/findAll")
+	@ApiOperation(value = "Finds all Pets", notes = "Returns a paginated list of all the Pets.")
+	@ApiResponses(value = { @ApiResponse(code = 400, message = "Invalid page value") })
+	public PagedList<Pet> findAllPaginated(
+			@ApiParam(value = "pageNumber", required = true) @QueryParam("pageNumber") int pageNumber) {
+		List<Pet> allPets = petData.findAllPets();
+		int pageSize = 5;
+		int startIndex = (pageNumber - 1) * pageSize;
+		int endIndex = startIndex + pageSize;
+		return new PagedList<Pet>(pageNumber, allPets.size(), allPets.subList(startIndex, endIndex));
+	}
 
     @POST
     @Path("/{petId}")

--- a/src/test/java/com/wordnik/jaxrs/PetResource.java
+++ b/src/test/java/com/wordnik/jaxrs/PetResource.java
@@ -185,7 +185,7 @@ public class PetResource {
 	@GET
 	@Path("/findAll")
 	@ApiOperation(value = "Finds all Pets", notes = "Returns a paginated list of all the Pets.")
-	@ApiResponses(value = { @ApiResponse(code = 400, message = "Invalid page value") })
+	@ApiResponses(value = { @ApiResponse(code = 400, message = "Invalid page number value") })
 	public PagedList<Pet> findAllPaginated(
 			@ApiParam(value = "pageNumber", required = true) @QueryParam("pageNumber") int pageNumber) {
 		List<Pet> allPets = petData.findAllPets();

--- a/src/test/java/com/wordnik/sample/data/PetData.java
+++ b/src/test/java/com/wordnik/sample/data/PetData.java
@@ -111,6 +111,10 @@ public class PetData {
         return result;
     }
 
+	public List<Pet> findAllPets() {
+		return Collections.unmodifiableList(pets);
+	}
+
     public Pet addPet(Pet pet) {
         if (pet.getId().value() == 0) {
             long maxId = 0;

--- a/src/test/resources/expectedOutput/swagger-with-converter.json
+++ b/src/test/resources/expectedOutput/swagger-with-converter.json
@@ -206,6 +206,49 @@
         ]
       }
     },
+    "/pet/findAll" : {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary" : "Finds all Pets",
+        "description" : "Returns a paginated list of all the Pets.",
+        "operationId": "findAllPaginated",
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
+        "parameters" : [
+          {
+            "name" : "pageNumber",
+            "in" : "query",
+            "description" : "pageNumber",
+            "required" : true,
+            "type":"integer",
+            "format" : "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/PagedListPet"
+            }
+          },
+          "400": {
+            "description": "Invalid page number value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
     "/pet/findByStatus": {
       "get": {
         "tags": [
@@ -1501,6 +1544,44 @@
       "xml": {
         "name": "Order"
       }
+    },
+    "PagedList" : {
+    	"type" : "object",
+    	"properties" : {
+    	  "items" : {
+    	  	"type" : "array",
+    	  	"items" : {
+    	  	  "type" : "object"
+    	  	}
+    	  },
+    	  "pageNumber" : {
+    	    "type" : "integer",
+    	    "format" : "int32"
+    	  },
+    	  "totalItems" : {
+    	    "type" : "integer",
+    	    "format" : "int32"
+    	  }
+    	}
+    },
+    "PagedListPet" : {
+    	"type" : "object",
+    	"properties" : {
+    	  "items" : {
+    	  	"type" : "array",
+    	  	"items" : {
+    	  	  "$ref" : "#/definitions/Pet"
+    	  	}
+    	  },
+    	  "pageNumber" : {
+    	    "type" : "integer",
+    	    "format" : "int32"
+    	  },
+    	  "totalItems" : {
+    	    "type" : "integer",
+    	    "format" : "int32"
+    	  }
+    	}
     },
     "Pet": {
       "type": "object",

--- a/src/test/resources/expectedOutput/swagger-with-converter.yaml
+++ b/src/test/resources/expectedOutput/swagger-with-converter.yaml
@@ -143,6 +143,34 @@ paths:
       - petstore_auth:
         - "write:pets"
         - "read:pets"
+  /pet/findAll:
+    get:
+      tags:
+      - "pet"
+      summary: "Finds all Pets"
+      description: "Returns a paginated list of all the Pets."
+      operationId: "findAllPaginated"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "pageNumber"
+        in: "query"
+        description: "pageNumber"
+        required: true
+        type: "integer"
+        format: "int32"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/PagedListPet"
+        400:
+          description: "Invalid page number value"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
   /pet/findByStatus:
     get:
       tags:
@@ -1048,6 +1076,32 @@ definitions:
         type: "string"
     xml:
       name: "Order"
+  PagedList:
+    type: "object"
+    properties:
+      items:
+        type: "array"
+        items:
+          type: "object"
+      pageNumber:
+        type: "integer"
+        format: "int32"
+      totalItems:
+        type: "integer"
+        format: "int32"
+  PagedListPet:
+    type: "object"
+    properties:
+      items:
+        type: "array"
+        items:
+          $ref: "#/definitions/Pet"
+      pageNumber:
+        type: "integer"
+        format: "int32"
+      totalItems:
+        type: "integer"
+        format: "int32"
   Pet:
     type: "object"
     required:

--- a/src/test/resources/expectedOutput/swagger.json
+++ b/src/test/resources/expectedOutput/swagger.json
@@ -206,6 +206,49 @@
         ]
       }
     },
+    "/pet/findAll" : {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary" : "Finds all Pets",
+        "description" : "Returns a paginated list of all the Pets.",
+        "operationId": "findAllPaginated",
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
+        "parameters" : [
+          {
+            "name" : "pageNumber",
+            "in" : "query",
+            "description" : "pageNumber",
+            "required" : true,
+            "type":"integer",
+            "format" : "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/PagedListPet"
+            }
+          },
+          "400": {
+            "description": "Invalid page number value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
     "/pet/findByStatus": {
       "get": {
         "tags": [
@@ -1507,6 +1550,44 @@
       "xml": {
         "name": "Order"
       }
+    },
+    "PagedList" : {
+    	"type" : "object",
+    	"properties" : {
+    	  "items" : {
+    	  	"type" : "array",
+    	  	"items" : {
+    	  	  "type" : "object"
+    	  	}
+    	  },
+    	  "pageNumber" : {
+    	    "type" : "integer",
+    	    "format" : "int32"
+    	  },
+    	  "totalItems" : {
+    	    "type" : "integer",
+    	    "format" : "int32"
+    	  }
+    	}
+    },
+    "PagedListPet" : {
+    	"type" : "object",
+    	"properties" : {
+    	  "items" : {
+    	  	"type" : "array",
+    	  	"items" : {
+    	  	  "$ref" : "#/definitions/Pet"
+    	  	}
+    	  },
+    	  "pageNumber" : {
+    	    "type" : "integer",
+    	    "format" : "int32"
+    	  },
+    	  "totalItems" : {
+    	    "type" : "integer",
+    	    "format" : "int32"
+    	  }
+    	}
     },
     "Pet": {
       "type": "object",

--- a/src/test/resources/expectedOutput/swagger.yaml
+++ b/src/test/resources/expectedOutput/swagger.yaml
@@ -143,6 +143,34 @@ paths:
       - petstore_auth:
         - "write:pets"
         - "read:pets"
+  /pet/findAll:
+    get:
+      tags:
+      - "pet"
+      summary: "Finds all Pets"
+      description: "Returns a paginated list of all the Pets."
+      operationId: "findAllPaginated"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "pageNumber"
+        in: "query"
+        description: "pageNumber"
+        required: true
+        type: "integer"
+        format: "int32"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/PagedListPet"
+        400:
+          description: "Invalid page number value"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
   /pet/findByStatus:
     get:
       tags:
@@ -1048,6 +1076,32 @@ definitions:
         type: "string"
     xml:
       name: "Order"
+  PagedList:
+    type: "object"
+    properties:
+      items:
+        type: "array"
+        items:
+          type: "object"
+      pageNumber:
+        type: "integer"
+        format: "int32"
+      totalItems:
+        type: "integer"
+        format: "int32"
+  PagedListPet:
+    type: "object"
+    properties:
+      items:
+        type: "array"
+        items:
+          $ref: "#/definitions/Pet"
+      pageNumber:
+        type: "integer"
+        format: "int32"
+      totalItems:
+        type: "integer"
+        format: "int32"
   Pet:
     type: "object"
     required:

--- a/src/test/resources/sample.html
+++ b/src/test/resources/sample.html
@@ -470,6 +470,93 @@ This is a contrived example
 
 
 
+## /pet/findAll
+
+
+### GET
+
+<a id="findAllPaginated">Finds all Pets</a>
+
+Returns a paginated list of all the Pets.
+
+
+
+
+#### Security
+
+
+
+
+* petstore_auth
+   * write:pets
+   * read:pets
+
+
+
+
+#### Request
+
+
+
+##### Parameters
+
+<table border="1">
+    <tr>
+        <th>Name</th>
+        <th>Located in</th>
+        <th>Required</th>
+        <th>Description</th>
+        <th>Default</th>
+        <th>Schema</th>
+    </tr>
+
+
+
+<tr>
+    <th>pageNumber</th>
+    <td>query</td>
+    <td>yes</td>
+    <td>pageNumber</td>
+    <td> - </td>
+
+
+            <td>integer (int32)</td>
+
+
+</tr>
+
+
+</table>
+
+
+
+#### Response
+
+**Content-Type: ** application/json, application/xml
+
+
+| Status Code | Reason      | Response Model |
+|-------------|-------------|----------------|
+| 200    | successful operation | <a href="#/definitions/PagedListPet">PagedListPet</a>|
+| 400    | Invalid page number value |  - |
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 ## /pet/findByStatus
 
 
@@ -3078,6 +3165,112 @@ This can only be done by the logged in user.
 
 
                 string
+
+            </td>
+            <td>optional</td>
+            <td>-</td>
+            <td></td>
+        </tr>
+
+</table>
+
+## <a name="/definitions/PagedList">PagedList</a>
+
+<table border="1">
+    <tr>
+        <th>name</th>
+        <th>type</th>
+        <th>required</th>
+        <th>description</th>
+        <th>example</th>
+    </tr>
+
+        <tr>
+            <td>pageNumber</td>
+            <td>
+
+
+                    integer (int32)
+
+            </td>
+            <td>optional</td>
+            <td>-</td>
+            <td></td>
+        </tr>
+
+        <tr>
+            <td>totalItems</td>
+            <td>
+
+
+                    integer (int32)
+
+            </td>
+            <td>optional</td>
+            <td>-</td>
+            <td></td>
+        </tr>
+
+        <tr>
+            <td>items</td>
+            <td>
+
+
+                    array[object]
+
+            </td>
+            <td>optional</td>
+            <td>-</td>
+            <td></td>
+        </tr>
+
+</table>
+
+## <a name="/definitions/PagedListPet">PagedListPet</a>
+
+<table border="1">
+    <tr>
+        <th>name</th>
+        <th>type</th>
+        <th>required</th>
+        <th>description</th>
+        <th>example</th>
+    </tr>
+
+        <tr>
+            <td>pageNumber</td>
+            <td>
+
+
+                    integer (int32)
+
+            </td>
+            <td>optional</td>
+            <td>-</td>
+            <td></td>
+        </tr>
+
+        <tr>
+            <td>totalItems</td>
+            <td>
+
+
+                    integer (int32)
+
+            </td>
+            <td>optional</td>
+            <td>-</td>
+            <td></td>
+        </tr>
+
+        <tr>
+            <td>items</td>
+            <td>
+
+
+                    array[<a href="#/definitions/Pet">Pet</a>]
+
+
 
             </td>
             <td>optional</td>


### PR DESCRIPTION
While writing a custom ModelConverter to use in the plugin I noticed that models where created for classes and not always their ParameterizedType counterparts. Information critical for building the models correctly was lost this way.

This change makes sure that the Type is always used, instead of Class to read a model.
