### PR TITLE
447: Add handling for absolute file path when loading JSON security def

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,16 @@ or define several definitions in a json file and specify the json path like this
     <json>/securityDefinition.json</json>
 </securityDefinition>
 ```
+
 The file will be read by `getClass().getResourceAsStream`, so please note the path you configured.
+
+Alternatively, specify the __absolute__ file path to the json definition file: 
+
+```xml
+<securityDefinition>
+    <jsonPath>${basedir}/securityDefinition.json</jsonPath>
+</securityDefinition>
+```
 
 The `securityDefinition.json` file should also follow the spec, one sample file like this:
 

--- a/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/SecurityDefinition.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/SecurityDefinition.java
@@ -8,7 +8,9 @@ import io.swagger.models.auth.BasicAuthDefinition;
 import io.swagger.models.auth.OAuth2Definition;
 import io.swagger.models.auth.SecuritySchemeDefinition;
 
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -21,14 +23,16 @@ public class SecurityDefinition {
     private String type;
     private String description;
     private String json;
+    private String jsonPath;
 
     public Map<String, SecuritySchemeDefinition> getDefinitions() throws GenerateException {
         Map<String, SecuritySchemeDefinition> map = new HashMap<String, SecuritySchemeDefinition>();
         if (name != null && type != null) {
             map.put(name, getSecuritySchemeDefinitionByNameAndType());
-        } else if (json != null) {
+        } else if (json != null || jsonPath != null) {
             try {
-                JsonNode tree = new ObjectMapper().readTree(this.getClass().getResourceAsStream(json));
+                InputStream jsonStream = json != null ? this.getClass().getResourceAsStream(json) : new FileInputStream(jsonPath);
+                JsonNode tree = new ObjectMapper().readTree(jsonStream);
                 Iterator<String> fit = tree.fieldNames();
                 while (fit.hasNext()) {
                     String field = fit.next();
@@ -139,5 +143,13 @@ public class SecurityDefinition {
 
     public void setType(String type) {
         this.type = type;
+    }
+
+    public String getJsonPath() {
+        return jsonPath;
+    }
+
+    public void setJsonPath(String jsonPath) {
+        this.jsonPath = jsonPath;
     }
 }

--- a/src/test/resources/plugin-config-multiple-api-sources.xml
+++ b/src/test/resources/plugin-config-multiple-api-sources.xml
@@ -59,7 +59,7 @@
                                     <type>basic</type>
                                 </securityDefinition>
                                 <securityDefinition>
-                                    <json>/securityDefinition.json</json>
+                                    <jsonPath>${basedir}/src/test/resources/securityDefinition.json</jsonPath>
                                 </securityDefinition>
                             </securityDefinitions>
                             <!-- Support classpath or file absolute path here.


### PR DESCRIPTION
Issue #447 discusses problems loading the definition file via the classloader. In addition it also relates to the issue https://github.com/gigaSproule/swagger-gradle-plugin/issues/15 in the derivative wrapper for Gradle. 
This PR adds handling for absolute file path to the JSON file bypassing the classloader thus allowing the file to be referenced anywhere on the local system. 