### PR TITLE
Upgrading Jackson Dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <java.version>1.6</java.version>
         <swagger.version>1.5.16</swagger.version>
         <github.global.server>github</github.global.server>
-        <jackson.version>2.8.4</jackson.version>
+        <jackson.version>2.8.9</jackson.version>
         <log4j.version>1.2.16</log4j.version>
         <handlebars.version>1.3.2</handlebars.version>
         <testng.version>6.8.8</testng.version>


### PR DESCRIPTION
This version of Jackson causes serialization error w/ ObjectNode.