### PR TITLE
Feature - Generate Docs For Services Without Swagger Annotations

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiSource.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiSource.java
@@ -5,14 +5,15 @@ import io.swagger.models.Contact;
 import io.swagger.models.Info;
 import io.swagger.models.License;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.reflections.ReflectionUtils;
 import org.reflections.Reflections;
-import org.reflections.scanners.SubTypesScanner;
 import org.springframework.core.annotation.AnnotationUtils;
 
 import java.io.File;
 import java.lang.annotation.Annotation;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * User: kongchen
@@ -65,7 +66,7 @@ public class ApiSource {
 
     @Parameter
     private String swaggerDirectory;
-
+    
     @Parameter
     private String swaggerFileName;
 
@@ -100,10 +101,10 @@ public class ApiSource {
 
     @Parameter
     private boolean useJAXBAnnotationProcessor;
-
+    
     @Parameter
     private boolean useJAXBAnnotationProcessorAsPrimary = true;
-
+    
     @Parameter
     private String swaggerSchemaConverter;
 
@@ -126,50 +127,21 @@ public class ApiSource {
     private List<String> modelConverters;
 
     public Set<Class<?>> getValidClasses(Class<? extends Annotation> clazz) {
-        List<String> locations = getLocations();
-        if (locations == null) {
-            locations = Arrays.asList("");
-        }
-        Set<Class<?>> classes;
-        if(clazz == null) {
-            classes = getValidClasses(locations);
-        }
-        else {
-            classes = getValidClasses(locations, clazz);
-        }
-
-        return classes;
-    }
-
-    private Set<Class<?>> getValidClasses(List<String> locations) {
-        Set<String> locationSet = new HashSet<String>(locations);
         Set<Class<?>> classes = new LinkedHashSet<Class<?>>();
-
-        // TODO Improve performance using getFieldsAnnotatedWith
-        Reflections reflections = new Reflections("", new SubTypesScanner(false));
-        Set<Class<?>> allClasses = reflections.getSubTypesOf(Object.class);
-        if(locations.contains("")) {
-            classes.addAll(allClasses);
-        }
-        else {
-            for (Class<?> clazz : allClasses) {
-                if (locationSet.contains(clazz.getPackage().getName())) {
-                    classes.add(clazz);
-                }
-            }
-        }
-
-        return classes;
-    }
-
-    private Set<Class<?>> getValidClasses(List<String> locations, Class<? extends Annotation> clazz) {
-        Set<Class<?>> classes = new LinkedHashSet<Class<?>>();
-        for (String location : locations) {
-            Set<Class<?>> c = new Reflections(location).getTypesAnnotatedWith(clazz, true);
+        if (getLocations() == null) {
+            Set<Class<?>> c = new Reflections("").getTypesAnnotatedWith(clazz, true);
             classes.addAll(c);
 
-            Set<Class<?>> inherited = new Reflections(location).getTypesAnnotatedWith(clazz);
+            Set<Class<?>> inherited = new Reflections("").getTypesAnnotatedWith(clazz);
             classes.addAll(inherited);
+        } else {
+            for (String location : locations) {
+                Set<Class<?>> c = new Reflections(location).getTypesAnnotatedWith(clazz, true);
+                classes.addAll(c);
+
+                Set<Class<?>> inherited = new Reflections(location).getTypesAnnotatedWith(clazz);
+                classes.addAll(inherited);
+            }
         }
 
         return classes;
@@ -303,7 +275,7 @@ public class ApiSource {
     public void setSwaggerDirectory(String swaggerDirectory) {
         this.swaggerDirectory = swaggerDirectory;
     }
-
+    
     public String getSwaggerFileName() {
         return swaggerFileName;
     }

--- a/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/MavenDocumentSource.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/MavenDocumentSource.java
@@ -4,6 +4,7 @@ import com.github.kongchen.swagger.docgen.AbstractDocumentSource;
 import com.github.kongchen.swagger.docgen.GenerateException;
 import com.github.kongchen.swagger.docgen.reader.ClassSwaggerReader;
 import com.github.kongchen.swagger.docgen.reader.JaxrsReader;
+import com.google.common.collect.Sets;
 import io.swagger.annotations.Api;
 import io.swagger.config.FilterFactory;
 import io.swagger.core.filter.SpecFilter;
@@ -11,7 +12,9 @@ import io.swagger.core.filter.SwaggerSpecFilter;
 import io.swagger.models.auth.SecuritySchemeDefinition;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
+import org.springframework.web.bind.annotation.RestController;
 
+import javax.ws.rs.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,7 +45,7 @@ public class MavenDocumentSource extends AbstractDocumentSource {
             }
         }
 
-        swagger = resolveApiReader().read(apiSource.getValidClasses(Api.class));
+        swagger = resolveApiReader().read(getValidClasses());
 
         if (apiSource.getSecurityDefinitions() != null) {
             for (SecurityDefinition sd : apiSource.getSecurityDefinitions()) {
@@ -65,6 +68,13 @@ public class MavenDocumentSource extends AbstractDocumentSource {
                     new HashMap<String, List<String>>(), new HashMap<String, String>(),
                     new HashMap<String, List<String>>());
         }
+    }
+
+    protected Sets.SetView<Class<?>> getValidClasses()
+    {
+        return Sets.union(
+                apiSource.getValidClasses(Api.class),
+                apiSource.getValidClasses(Path.class));
     }
 
     private ClassSwaggerReader resolveApiReader() throws GenerateException {

--- a/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/MavenDocumentSource.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/MavenDocumentSource.java
@@ -42,7 +42,7 @@ public class MavenDocumentSource extends AbstractDocumentSource {
             }
         }
 
-        swagger = resolveApiReader().read(apiSource.getValidClasses(null));
+        swagger = resolveApiReader().read(apiSource.getValidClasses(Api.class));
 
         if (apiSource.getSecurityDefinitions() != null) {
             for (SecurityDefinition sd : apiSource.getSecurityDefinitions()) {

--- a/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/MavenDocumentSource.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/MavenDocumentSource.java
@@ -42,7 +42,7 @@ public class MavenDocumentSource extends AbstractDocumentSource {
             }
         }
 
-        swagger = resolveApiReader().read(apiSource.getValidClasses(Api.class));
+        swagger = resolveApiReader().read(apiSource.getValidClasses(null));
 
         if (apiSource.getSecurityDefinitions() != null) {
             for (SecurityDefinition sd : apiSource.getSecurityDefinitions()) {

--- a/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/SpringMavenDocumentSource.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/SpringMavenDocumentSource.java
@@ -69,7 +69,7 @@ public class SpringMavenDocumentSource extends AbstractDocumentSource {
         }
     }
 
-    Sets.SetView<Class<?>> getValidClasses()
+    protected Sets.SetView<Class<?>> getValidClasses()
     {
         return Sets.union(
             apiSource.getValidClasses(Api.class),

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
@@ -116,6 +116,10 @@ public abstract class AbstractReader {
 
     protected List<SecurityRequirement> getSecurityRequirements(Api api) {
         List<SecurityRequirement> securities = new ArrayList<SecurityRequirement>();
+        if(api == null) {
+            return securities;
+        }
+
         for (Authorization auth : api.authorizations()) {
             if (auth.value().isEmpty()) {
                 continue;
@@ -236,12 +240,15 @@ public abstract class AbstractReader {
         }
     }
 
-    protected boolean canReadApi(boolean readHidden, Api api) {
-        return (api != null && readHidden) || (api != null && !api.hidden());
+    protected boolean canReadApi(Class<?> cls, boolean readHidden, Api api) {
+        return !cls.isInterface() && ((api == null) || (readHidden) || (!api.hidden()));
     }
 
     protected Set<Tag> extractTags(Api api) {
         Set<Tag> output = new LinkedHashSet<Tag>();
+        if(api == null) {
+            return output;
+        }
 
         boolean hasExplicitTags = false;
         for (String tag : api.tags()) {

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
@@ -265,6 +265,9 @@ public abstract class AbstractReader {
     }
 
     protected void updateOperationProtocols(ApiOperation apiOperation, Operation operation) {
+        if(apiOperation == null) {
+            return;
+        }
         String[] protocols = apiOperation.protocols().split(",");
         for (String protocol : protocols) {
             String trimmed = protocol.trim();

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
@@ -116,10 +116,6 @@ public abstract class AbstractReader {
 
     protected List<SecurityRequirement> getSecurityRequirements(Api api) {
         List<SecurityRequirement> securities = new ArrayList<SecurityRequirement>();
-        if(api == null) {
-            return securities;
-        }
-
         for (Authorization auth : api.authorizations()) {
             if (auth.value().isEmpty()) {
                 continue;
@@ -240,15 +236,12 @@ public abstract class AbstractReader {
         }
     }
 
-    protected boolean canReadApi(Class<?> cls, boolean readHidden, Api api) {
-        return !cls.isInterface() && ((api == null) || (readHidden) || (!api.hidden()));
+    protected boolean canReadApi(boolean readHidden, Api api) {
+        return (api != null && readHidden) || (api != null && !api.hidden());
     }
 
     protected Set<Tag> extractTags(Api api) {
         Set<Tag> output = new LinkedHashSet<Tag>();
-        if(api == null) {
-            return output;
-        }
 
         boolean hasExplicitTags = false;
         for (String tag : api.tags()) {

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
@@ -116,6 +116,10 @@ public abstract class AbstractReader {
 
     protected List<SecurityRequirement> getSecurityRequirements(Api api) {
         List<SecurityRequirement> securities = new ArrayList<SecurityRequirement>();
+        if(api == null) {
+            return securities;
+        }
+
         for (Authorization auth : api.authorizations()) {
             if (auth.value().isEmpty()) {
                 continue;
@@ -237,11 +241,14 @@ public abstract class AbstractReader {
     }
 
     protected boolean canReadApi(boolean readHidden, Api api) {
-        return (api != null && readHidden) || (api != null && !api.hidden());
+        return (api == null) || (readHidden) || (!api.hidden());
     }
 
     protected Set<Tag> extractTags(Api api) {
         Set<Tag> output = new LinkedHashSet<Tag>();
+        if(api == null) {
+            return output;
+        }
 
         boolean hasExplicitTags = false;
         for (String tag : api.tags()) {

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
@@ -79,7 +79,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
         Path apiPath = AnnotationUtils.findAnnotation(cls, Path.class);
 
         // only read if allowing hidden apis OR api is not marked as hidden
-        if (!canReadApi(readHidden, api)) {
+        if (!canReadApi(cls, readHidden, api)) {
             return swagger;
         }
 
@@ -95,17 +95,16 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
         // parse the method
         for (Method method : cls.getMethods()) {
             ApiOperation apiOperation = AnnotationUtils.findAnnotation(method, ApiOperation.class);
-            if (apiOperation == null || apiOperation.hidden()) {
+            if (apiOperation != null && apiOperation.hidden()) {
                 continue;
             }
             Path methodPath = AnnotationUtils.findAnnotation(method, Path.class);
 
             String operationPath = getPath(apiPath, methodPath, parentPath);
-            if (operationPath != null) {
+            String httpMethod = extractOperationMethod(apiOperation, method, SwaggerExtensions.chain());
+            if (operationPath != null && (httpMethod != null || parentMethod != null)) {
                 Map<String, String> regexMap = new HashMap<String, String>();
                 operationPath = parseOperationPath(operationPath, regexMap);
-
-                String httpMethod = extractOperationMethod(apiOperation, method, SwaggerExtensions.chain());
 
                 Operation operation = parseMethod(method);
                 updateOperationParameters(parentParameters, regexMap, operation);
@@ -177,7 +176,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
 
     private String getPath(Path classLevelPath, Path methodLevelPath, String parentPath) {
         if (classLevelPath == null && methodLevelPath == null) {
-            return null;
+            return "";
         }
         StringBuilder stringBuilder = new StringBuilder();
         if (parentPath != null && !parentPath.isEmpty() && !parentPath.equals("/")) {
@@ -216,6 +215,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
 
 
     public Operation parseMethod(Method method) {
+        int responseCode = 200;
         Operation operation = new Operation();
         ApiOperation apiOperation = AnnotationUtils.findAnnotation(method, ApiOperation.class);
 
@@ -271,6 +271,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
             for (SecurityRequirement sec : securities) {
                 operation.security(sec);
             }
+            responseCode = apiOperation.code();
         }
         operation.operationId(operationId);
 
@@ -279,17 +280,21 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
             LOGGER.debug("picking up response class from method " + method);
             responseClassType = method.getGenericReturnType();
         }
+        boolean hasApiAnnotation = false;
+        if (responseClassType instanceof Class) {
+            hasApiAnnotation = AnnotationUtils.findAnnotation((Class) responseClassType, Api.class) != null;
+        }
         if ((responseClassType != null)
                 && !responseClassType.equals(Void.class)
                 && !responseClassType.equals(void.class)
                 && !responseClassType.equals(javax.ws.rs.core.Response.class)
-                && (AnnotationUtils.findAnnotation(convertToClass(responseClassType), Api.class) == null)) {
+                && !hasApiAnnotation) {
             if (isPrimitive(responseClassType)) {
                 Property property = ModelConverters.getInstance().readAsProperty(responseClassType);
                 if (property != null) {
                     Property responseProperty = RESPONSE_CONTAINER_CONVERTER.withResponseContainer(responseContainer, property);
 
-                    operation.response(apiOperation.code(), new Response()
+                    operation.response(responseCode, new Response()
                             .description("successful operation")
                             .schema(responseProperty)
                             .headers(defaultResponseHeaders));
@@ -298,7 +303,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
                 Map<String, Model> models = ModelConverters.getInstance().read(responseClassType);
                 if (models.isEmpty()) {
                     Property p = ModelConverters.getInstance().readAsProperty(responseClassType);
-                    operation.response(apiOperation.code(), new Response()
+                    operation.response(responseCode, new Response()
                             .description("successful operation")
                             .schema(p)
                             .headers(defaultResponseHeaders));
@@ -307,7 +312,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
                     Property responseProperty = RESPONSE_CONTAINER_CONVERTER.withResponseContainer(responseContainer, new RefProperty().asDefault(key));
 
 
-                    operation.response(apiOperation.code(), new Response()
+                    operation.response(responseCode, new Response()
                             .description("successful operation")
                             .schema(responseProperty)
                             .headers(defaultResponseHeaders));
@@ -377,18 +382,6 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
         return operation;
     }
 
-	private Class<?> convertToClass(Type type) {
-		Type typeToConvert = type;
-		if (type instanceof ParameterizedType) {
-			typeToConvert = ((ParameterizedType) type).getRawType();
-		}
-		try {
-			return Class.forName(getClassName(typeToConvert));
-		} catch (ClassNotFoundException e) {
-			throw new RuntimeException(e);
-		}
-	}
-
 	private static String getClassName(Type type) {
 		String fullName = type.toString();
 		if (fullName.startsWith(CLASS_NAME_PREFIX)) {
@@ -430,7 +423,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
 	}
 
 	public String extractOperationMethod(ApiOperation apiOperation, Method method, Iterator<SwaggerExtension> chain) {
-        if (!apiOperation.httpMethod().isEmpty()) {
+        if (apiOperation != null && !apiOperation.httpMethod().isEmpty()) {
             return apiOperation.httpMethod().toLowerCase();
         } else if (AnnotationUtils.findAnnotation(method, GET.class) != null) {
             return "get";

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiReader.java
@@ -83,7 +83,7 @@ public class SpringMvcApiReader extends AbstractReader implements ClassSwaggerRe
 
         if (controller.isAnnotationPresent(Api.class)) {
             Api api = AnnotatedElementUtils.findMergedAnnotation(controller, Api.class);
-            if (!canReadApi(false, api)) {
+            if (!canReadApi(controller, false, api)) {
                 return swagger;
             }
             tags = updateTagsForApi(null, api);

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiReader.java
@@ -83,7 +83,7 @@ public class SpringMvcApiReader extends AbstractReader implements ClassSwaggerRe
 
         if (controller.isAnnotationPresent(Api.class)) {
             Api api = AnnotatedElementUtils.findMergedAnnotation(controller, Api.class);
-            if (!canReadApi(controller, false, api)) {
+            if (!canReadApi(false, api)) {
                 return swagger;
             }
             tags = updateTagsForApi(null, api);

--- a/src/test/java/com/wordnik/jaxrs/SwaggerlessResource.java
+++ b/src/test/java/com/wordnik/jaxrs/SwaggerlessResource.java
@@ -1,0 +1,36 @@
+package com.wordnik.jaxrs;
+
+import com.wordnik.sample.model.Pet;
+import com.wordnik.sample.model.PetName;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+public class SwaggerlessResource {
+
+    @GET
+    @Path("/swaggerless/{petId : [0-9]}")
+    public Pet getPetByName(@PathParam(value = "name") String name) {
+        // Just create and return a new pet
+        Pet pet = new Pet();
+        pet.setName(new PetName(name));
+        return pet;
+    }
+
+    public Pet notAnEndpoint(@PathParam(value = "name") String name) {
+        // Just create and return a new pet
+        Pet pet = new Pet();
+        pet.setName(new PetName(name));
+        return pet;
+    }
+
+    @Path("/swaggerless")
+    public Pet notAnEndpointWithPath(@RequestParam(value = "name") String name) {
+        // Just create and return a new pet
+        Pet pet = new Pet();
+        pet.setName(new PetName(name));
+        return pet;
+    }
+}

--- a/src/test/java/com/wordnik/jaxrs/SwaggerlessResource.java
+++ b/src/test/java/com/wordnik/jaxrs/SwaggerlessResource.java
@@ -7,7 +7,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
 
+@Path("/")
 public class SwaggerlessResource {
 
     @GET
@@ -32,5 +34,10 @@ public class SwaggerlessResource {
         Pet pet = new Pet();
         pet.setName(new PetName(name));
         return pet;
+    }
+
+    @Path("/swaggerless/subresource")
+    public SwaggerlessSubresource subresourceEndpoint() {
+        return new SwaggerlessSubresource();
     }
 }

--- a/src/test/java/com/wordnik/jaxrs/SwaggerlessSubresource.java
+++ b/src/test/java/com/wordnik/jaxrs/SwaggerlessSubresource.java
@@ -1,0 +1,20 @@
+package com.wordnik.jaxrs;
+
+import com.wordnik.sample.model.Pet;
+import com.wordnik.sample.model.PetName;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+public class SwaggerlessSubresource {
+
+    @GET
+    @Path("/{name}")
+    public Pet getPetByNameSubresource(@PathParam(value = "name") String name) {
+        // Just create and return a new pet
+        Pet pet = new Pet();
+        pet.setName(new PetName(name));
+        return pet;
+    }
+}

--- a/src/test/java/com/wordnik/springmvc/SwaggerlessResource.java
+++ b/src/test/java/com/wordnik/springmvc/SwaggerlessResource.java
@@ -1,0 +1,27 @@
+package com.wordnik.springmvc;
+
+import com.wordnik.sample.model.Pet;
+import com.wordnik.sample.model.PetName;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class SwaggerlessResource {
+
+    @RequestMapping(value = "/swaggerless/{petId}", method = RequestMethod.GET)
+    public Pet getPetByName(@PathVariable(value = "name") String name) {
+        // Just create and return a new pet
+        Pet pet = new Pet();
+        pet.setName(new PetName(name));
+        return pet;
+    }
+
+    public Pet notAnEndpoint(@PathVariable(value = "name") String name) {
+        // Just create and return a new pet
+        Pet pet = new Pet();
+        pet.setName(new PetName(name));
+        return pet;
+    }
+}

--- a/src/test/resources/expectedOutput/swagger-spring.json
+++ b/src/test/resources/expectedOutput/swagger-spring.json
@@ -818,6 +818,25 @@
         }
       }
     },
+    "/swaggerless/{petId}" : {
+      "get" : {
+        "operationId" : "getPetByName",
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/Pet"
+            }
+          }
+        }
+      }
+    },
     "/user" : {
       "post" : {
         "tags" : [ "user" ],

--- a/src/test/resources/expectedOutput/swagger-spring.yaml
+++ b/src/test/resources/expectedOutput/swagger-spring.yaml
@@ -741,6 +741,19 @@ paths:
           description: "successful operation"
           schema:
             type: "string"
+  /swaggerless/{petId}:
+    get:
+      operationId: "getPetByName"
+      parameters:
+      - name: "name"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Pet"
   /user:
     post:
       tags:

--- a/src/test/resources/expectedOutput/swagger-with-converter.json
+++ b/src/test/resources/expectedOutput/swagger-with-converter.json
@@ -1229,6 +1229,25 @@
         }
       }
     },
+    "/swaggerless/subresource/{name}" : {
+      "get" : {
+        "operationId" : "getPetByNameSubresource",
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/Pet"
+            }
+          }
+        }
+      }
+    },
     "/swaggerless/{petId}" : {
       "get" : {
         "operationId" : "getPetByName",

--- a/src/test/resources/expectedOutput/swagger-with-converter.json
+++ b/src/test/resources/expectedOutput/swagger-with-converter.json
@@ -1229,6 +1229,25 @@
         }
       }
     },
+    "/swaggerless/{petId}" : {
+      "get" : {
+        "operationId" : "getPetByName",
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+             "$ref" : "#/definitions/Pet"
+            }
+          }
+        }
+      }
+    },
     "/user": {
       "post": {
         "tags": [

--- a/src/test/resources/expectedOutput/swagger-with-converter.yaml
+++ b/src/test/resources/expectedOutput/swagger-with-converter.yaml
@@ -862,6 +862,19 @@ paths:
           description: "Successful request - see response for 'pong'"
           schema:
             type: "string"
+  /swaggerless/subresource/{name}:
+    get:
+      operationId: "getPetByNameSubresource"
+      parameters:
+      - name: "name"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Pet"
   /swaggerless/{petId}:
     get:
       operationId: "getPetByName"

--- a/src/test/resources/expectedOutput/swagger-with-converter.yaml
+++ b/src/test/resources/expectedOutput/swagger-with-converter.yaml
@@ -862,6 +862,19 @@ paths:
           description: "Successful request - see response for 'pong'"
           schema:
             type: "string"
+  /swaggerless/{petId}:
+    get:
+      operationId: "getPetByName"
+      parameters:
+      - name: "name"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Pet"
   /user:
     post:
       tags:

--- a/src/test/resources/expectedOutput/swagger.json
+++ b/src/test/resources/expectedOutput/swagger.json
@@ -1235,6 +1235,25 @@
         }
       }
     },
+    "/swaggerless/subresource/{name}" : {
+      "get" : {
+        "operationId" : "getPetByNameSubresource",
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/Pet"
+            }
+          }
+        }
+      }
+    },
     "/swaggerless/{petId}" : {
       "get" : {
         "operationId" : "getPetByName",

--- a/src/test/resources/expectedOutput/swagger.json
+++ b/src/test/resources/expectedOutput/swagger.json
@@ -1235,6 +1235,25 @@
         }
       }
     },
+    "/swaggerless/{petId}" : {
+      "get" : {
+        "operationId" : "getPetByName",
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/Pet"
+            }
+          }
+        }
+      }
+    },
     "/user": {
       "post": {
         "tags": [

--- a/src/test/resources/expectedOutput/swagger.yaml
+++ b/src/test/resources/expectedOutput/swagger.yaml
@@ -862,6 +862,19 @@ paths:
           description: "Successful request - see response for 'pong'"
           schema:
             type: "string"
+  /swaggerless/subresource/{name}:
+    get:
+      operationId: "getPetByNameSubresource"
+      parameters:
+      - name: "name"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Pet"
   /swaggerless/{petId}:
     get:
       operationId: "getPetByName"

--- a/src/test/resources/expectedOutput/swagger.yaml
+++ b/src/test/resources/expectedOutput/swagger.yaml
@@ -862,6 +862,19 @@ paths:
           description: "Successful request - see response for 'pong'"
           schema:
             type: "string"
+  /swaggerless/{petId}:
+    get:
+      operationId: "getPetByName"
+      parameters:
+      - name: "name"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Pet"
   /user:
     post:
       tags:

--- a/src/test/resources/sample-springmvc.html
+++ b/src/test/resources/sample-springmvc.html
@@ -2084,6 +2084,83 @@ For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values w
 
 
 
+## /swaggerless/{petId}
+
+
+### GET
+
+<a id="getPetByName"></a>
+
+
+
+
+
+
+
+
+
+#### Request
+
+
+
+##### Parameters
+
+<table border="1">
+    <tr>
+        <th>Name</th>
+        <th>Located in</th>
+        <th>Required</th>
+        <th>Description</th>
+        <th>Default</th>
+        <th>Schema</th>
+    </tr>
+
+
+
+<tr>
+    <th>name</th>
+    <td>path</td>
+    <td>yes</td>
+    <td></td>
+    <td> - </td>
+
+    
+            <td>string </td>
+    
+
+</tr>
+
+
+</table>
+
+
+
+#### Response
+
+
+
+
+| Status Code | Reason      | Response Model |
+|-------------|-------------|----------------|
+| 200    | successful operation | <a href="#/definitions/Pet">Pet</a>|
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 ## /testingEmptyRootPathResource
 
 

--- a/src/test/resources/sample.html
+++ b/src/test/resources/sample.html
@@ -2484,6 +2484,83 @@ For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values w
 
 
 
+## /swaggerless/{petId}
+
+
+### GET
+
+<a id="getPetByName"></a>
+
+
+
+
+
+
+
+
+
+#### Request
+
+
+
+##### Parameters
+
+<table border="1">
+    <tr>
+        <th>Name</th>
+        <th>Located in</th>
+        <th>Required</th>
+        <th>Description</th>
+        <th>Default</th>
+        <th>Schema</th>
+    </tr>
+
+
+
+<tr>
+    <th>name</th>
+    <td>path</td>
+    <td>yes</td>
+    <td></td>
+    <td> - </td>
+
+    
+            <td>string </td>
+    
+
+</tr>
+
+
+</table>
+
+
+
+#### Response
+
+
+
+
+| Status Code | Reason      | Response Model |
+|-------------|-------------|----------------|
+| 200    | successful operation | <a href="#/definitions/Pet">Pet</a>|
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 ## /user
 
 

--- a/src/test/resources/sample.html
+++ b/src/test/resources/sample.html
@@ -2484,6 +2484,83 @@ For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values w
 
 
 
+## /swaggerless/subresource/{name}
+
+
+### GET
+
+<a id="getPetByNameSubresource"></a>
+
+
+
+
+
+
+
+
+
+#### Request
+
+
+
+##### Parameters
+
+<table border="1">
+    <tr>
+        <th>Name</th>
+        <th>Located in</th>
+        <th>Required</th>
+        <th>Description</th>
+        <th>Default</th>
+        <th>Schema</th>
+    </tr>
+
+
+
+<tr>
+    <th>name</th>
+    <td>path</td>
+    <td>yes</td>
+    <td></td>
+    <td> - </td>
+
+    
+            <td>string </td>
+    
+
+</tr>
+
+
+</table>
+
+
+
+#### Response
+
+
+
+
+| Status Code | Reason      | Response Model |
+|-------------|-------------|----------------|
+| 200    | successful operation | <a href="#/definitions/Pet">Pet</a>|
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 ## /swaggerless/{petId}
 
 


### PR DESCRIPTION
This addresses https://github.com/kongchen/swagger-maven-plugin/issues/508 and enables the plugin to generate Swagger documentation for services without Swagger annotations.  It will still read and use Swagger annotations if present but can also detect and document endpoints that are missing Swagger annotations.