### PR TITLE
support inherited @Api annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /.project
 /generated/
 /test-output/
+.factorypath
+.vscode

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiReader.java
@@ -93,7 +93,7 @@ public class SpringMvcApiReader extends AbstractReader implements ClassSwaggerRe
             controllerProduces = controllerRM.produces();
         }
 
-        if (controller.isAnnotationPresent(Api.class)) {
+        if (AnnotatedElementUtils.hasAnnotation(controller, Api.class)) {
             Api api = AnnotatedElementUtils.findMergedAnnotation(controller, Api.class);
             if (!canReadApi(false, api)) {
                 return swagger;


### PR DESCRIPTION
uses Springs annotation utils to search for the @Api annotation on superclasses (and interfaces), not just the RestController