### PR TITLE
Fixes #534 by scanning once per class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,12 +222,12 @@
             </plugin>
             <plugin>
                 <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-maven-plugin</artifactId>
-                <version>1.3.8</version>
+                <artifactId>plexus-component-metadata</artifactId>
+                <version>1.5.5</version>
                 <executions>
                     <execution>
                         <goals>
-                            <goal>descriptor</goal>
+                            <goal>generate-metadata</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -210,6 +210,11 @@
             <version>${junit-addons.version}</version>
 	    <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/com/github/kongchen/swagger/docgen/reader/JaxrsReaderTest.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/reader/JaxrsReaderTest.java
@@ -1,0 +1,118 @@
+package com.github.kongchen.swagger.docgen.reader;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.models.Swagger;
+import io.swagger.models.Tag;
+import io.swagger.models.parameters.Parameter;
+import org.apache.maven.plugin.logging.Log;
+
+import org.mockito.Mock;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+public class JaxrsReaderTest {
+  @Mock
+  private Log log;
+
+  private JaxrsReader reader;
+
+  @BeforeMethod
+  public void setup() {
+    Swagger swagger = new Swagger();
+    reader = new JaxrsReader(swagger, log);
+  }
+
+  @Test
+  public void ignoreClassIfNoApiAnnotation() {
+    Swagger result = reader.read(NotAnnotatedApi.class);
+
+    assertEmptySwaggerResponse(result);
+  }
+
+  @Test
+  public void ignoreApiIfHiddenAttributeIsTrue() {
+    Swagger result = reader.read(HiddenApi.class);
+
+    assertEmptySwaggerResponse(result);
+  }
+
+  @Test
+  public void includeApiIfHiddenParameterIsTrueAndApiHiddenAttributeIsTrue() {
+    Swagger result = reader.read(HiddenApi.class, "", null, true, new String[0], new String[0], new HashMap<String, Tag>(), new ArrayList<Parameter>());
+
+    assertNotNull(result, "No Swagger object created");
+    assertFalse(result.getTags().isEmpty(), "Should contain api tags");
+    assertFalse(result.getPaths().isEmpty(), "Should contain operation paths");
+  }
+
+  @Test
+  public void discoverApiOperation() {
+    Tag expectedTag = new Tag();
+    expectedTag.name("atag");
+    Swagger result = reader.read(AnApi.class);
+
+    assertSwaggerResponseContents(expectedTag, result);
+  }
+
+  @Test
+  public void createNewSwaggerInstanceIfNoneProvided() {
+    JaxrsReader nullReader = new JaxrsReader(null, log);
+    Tag expectedTag = new Tag();
+    expectedTag.name("atag");
+    Swagger result = nullReader.read(AnApi.class);
+
+    assertSwaggerResponseContents(expectedTag, result);
+  }
+
+  private void assertEmptySwaggerResponse(Swagger result) {
+    assertNotNull(result, "No Swagger object created");
+    assertNull(result.getTags(), "Should not have any tags");
+    assertNull(result.getPaths(), "Should not have any paths");
+  }
+
+  private void assertSwaggerResponseContents(Tag expectedTag, Swagger result) {
+    assertNotNull(result, "No Swagger object created");
+    assertFalse(result.getTags().isEmpty(), "Should contain api tags");
+    assertTrue(result.getTags().contains(expectedTag), "Expected tag missing");
+    assertFalse(result.getPaths().isEmpty(), "Should contain operation paths");
+    assertTrue(result.getPaths().containsKey("/apath"), "Path missing from paths map");
+    io.swagger.models.Path path = result.getPaths().get("/apath");
+    assertFalse(path.getOperations().isEmpty(), "Should be a get operation");
+  }
+
+  @Api(tags = "atag")
+  @Path("/apath")
+  static class AnApi {
+    @ApiOperation(value = "Get a model.")
+    @GET
+    public Response getOperation() {
+      return Response.ok().build();
+    }
+  }
+
+  @Api(hidden = true, tags = "atag")
+  @Path("/hidden/path")
+  static class HiddenApi {
+    @ApiOperation(value = "Get a model.")
+    @GET
+    public Response getOperation() {
+      return Response.ok().build();
+    }
+  }
+
+  @Path("/apath")
+  static class NotAnnotatedApi {
+  }
+}


### PR DESCRIPTION
This was the safest option. 

This will not remove all the duplication that an instance level variable would but it will remove duplication of classpath scans for each class.