### PR TITLE
don't skip methods without @ApiOperation in springmvc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,6 +210,12 @@
             <version>${junit-addons.version}</version>
 	    <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
@@ -22,6 +22,7 @@ import javax.ws.rs.QueryParam;
 
 import org.apache.commons.lang3.reflect.TypeUtils;
 import org.apache.maven.plugin.logging.Log;
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -516,6 +517,27 @@ public abstract class AbstractReader {
         }
 
         return ParameterProcessor.applyAnnotations(swagger, parameter, apiClass, Arrays.asList(new Annotation[]{param}));
+    }
+
+    protected ApiOperation getApiOperation(Method method) {
+        ApiOperation result = AnnotatedElementUtils.findMergedAnnotation(method, ApiOperation.class);
+        if (result == null) {
+            result = getDefaultApiOperation();
+        }
+        return result;
+    }
+
+    protected ApiOperation getDefaultApiOperation() {
+        try {
+            return AnnotatedElementUtils.findMergedAnnotation
+                    (getClass().getMethod("defaultApiOperation"), ApiOperation.class);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException("This should never happen");
+        }
+    }
+
+    @ApiOperation("")
+    public final void defaultApiOperation() {
     }
 
     void processOperationDecorator(Operation operation, Method method) {

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiReader.java
@@ -51,7 +51,7 @@ public class SpringMvcApiReader extends AbstractReader implements ClassSwaggerRe
     public SpringMvcApiReader(Swagger swagger, Log log) {
         super(swagger, log);
     }
-    
+
     @Override
     protected void updateExtensionChain() {
     	List<SwaggerExtension> extensions = new ArrayList<SwaggerExtension>();
@@ -113,8 +113,8 @@ public class SpringMvcApiReader extends AbstractReader implements ClassSwaggerRe
                 if (requestMapping == null) {
                     continue;
                 }
-                ApiOperation apiOperation = AnnotatedElementUtils.findMergedAnnotation(method, ApiOperation.class);
-                if (apiOperation == null || apiOperation.hidden()) {
+                ApiOperation apiOperation = getApiOperation(method);
+                if (apiOperation.hidden()) {
                     continue;
                 }
 
@@ -158,7 +158,7 @@ public class SpringMvcApiReader extends AbstractReader implements ClassSwaggerRe
         String responseContainer = null;
         String operationId = method.getName();
 
-        ApiOperation apiOperation = AnnotatedElementUtils.findMergedAnnotation(method, ApiOperation.class);
+        ApiOperation apiOperation = getApiOperation(method);
 
         if (apiOperation.hidden()) {
             return null;

--- a/src/test/java/com/github/kongchen/swagger/docgen/reader/AbstractReaderTest.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/reader/AbstractReaderTest.java
@@ -1,0 +1,57 @@
+package com.github.kongchen.swagger.docgen.reader;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.models.Swagger;
+import org.apache.maven.plugin.logging.Log;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Type;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class AbstractReaderTest {
+    private static final String ANNOTATED_METHOD = "Annotated method";
+
+    @Mock
+    private Log log;
+    @Mock
+    private Swagger swagger;
+
+    private AbstractReader reader;
+
+    @BeforeMethod
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        reader = new AbstractReader(swagger, log) {
+            @Override
+            public Set<Type> getTypesToSkip() {
+                return super.getTypesToSkip();
+            }
+        };
+    }
+
+    @ApiOperation(ANNOTATED_METHOD)
+    public final void annotatedMethod() {
+    }
+
+    public final void notAnnotatedMethod() {
+    }
+
+    @Test
+    public void getApiOperationReturnsMethodAnnotation() throws NoSuchMethodException {
+        ApiOperation result = reader.getApiOperation(getClass().getMethod("annotatedMethod"));
+        assertThat(result.value(), is(ANNOTATED_METHOD));
+    }
+
+    @Test
+    public void getApiOperationReturnsDefaultAnnotation() throws NoSuchMethodException {
+        ApiOperation result = reader.getApiOperation(getClass().getMethod("notAnnotatedMethod"));
+        assertThat(result.value(), is(""));
+    }
+
+}


### PR DESCRIPTION
Trying to generate swagger for our SpringBoot project, i've spent two days debugging your plugin to find out why my swagger json is empty. It turns out that if method is not annotated with `@ApiOperation` it's ignored.

Actually, we don't need this annotation to generate spec, so here is PR to fix it.