### PR TITLE
reset swagger extensions after tests

### DIFF
--- a/src/test/java/com/github/kongchen/smp/integration/SwaggerReaderTest.java
+++ b/src/test/java/com/github/kongchen/smp/integration/SwaggerReaderTest.java
@@ -1,31 +1,21 @@
 package com.github.kongchen.smp.integration;
 
-import static com.github.kongchen.smp.integration.utils.TestUtils.YamlToJson;
-import static com.github.kongchen.smp.integration.utils.TestUtils.changeDescription;
-import static net.javacrumbs.jsonunit.JsonAssert.assertJsonEquals;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.kongchen.swagger.docgen.mavenplugin.ApiDocumentMojo;
+import net.javacrumbs.jsonunit.core.Configuration;
 import org.apache.commons.io.FileUtils;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.yaml.snakeyaml.Yaml;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.kongchen.swagger.docgen.mavenplugin.ApiDocumentMojo;
+import java.io.File;
 
-import io.swagger.jaxrs.ext.SwaggerExtension;
-import io.swagger.jaxrs.ext.SwaggerExtensions;
-import net.javacrumbs.jsonunit.core.Configuration;
+import static com.github.kongchen.smp.integration.utils.TestUtils.YamlToJson;
+import static com.github.kongchen.smp.integration.utils.TestUtils.changeDescription;
+import static net.javacrumbs.jsonunit.JsonAssert.assertJsonEquals;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
 
 /**
  * @author chekong on 8/15/14.
@@ -34,12 +24,10 @@ public class SwaggerReaderTest extends AbstractMojoTestCase {
     private File swaggerOutputDir = new File(getBasedir(), "generated/swagger-ui");
     private ApiDocumentMojo mojo;
     private ObjectMapper mapper = new ObjectMapper();
-    private List<SwaggerExtension> extensions;
 
     @Override
 	@BeforeMethod
     protected void setUp() throws Exception {
-    	extensions = new ArrayList<SwaggerExtension>(SwaggerExtensions.getExtensions());
         super.setUp();
 
         try {
@@ -51,50 +39,33 @@ public class SwaggerReaderTest extends AbstractMojoTestCase {
         File testPom = new File(getBasedir(), "target/test-classes/plugin-config-swaggerreader.xml");
         mojo = (ApiDocumentMojo) lookupMojo("generate", testPom);
     }
-    
-    @Override
-    @AfterMethod
-    protected void tearDown() throws Exception {
-    	super.tearDown();
-    	SwaggerExtensions.setExtensions(extensions);
-    }
 
     @Test
     public void testGeneratedSwaggerSpecJson() throws Exception {
-        executeAndAssertGeneratedSwaggerSpecJson("This is a sample.", "/expectedOutput/swagger-swaggerreader.json");
+        mojo.execute();
+
+        JsonNode actualJson = mapper.readTree(new File(swaggerOutputDir, "swagger.json"));
+        JsonNode expectJson = mapper.readTree(this.getClass().getResourceAsStream("/expectedOutput/swagger-swaggerreader.json"));
+
+        changeDescription(expectJson, "This is a sample.");
+        assertJsonEquals(expectJson, actualJson, Configuration.empty().when(IGNORING_ARRAY_ORDER));
     }
 
     @Test
     public void testGeneratedSwaggerSpecYaml() throws Exception {
-        assertGeneratedSwaggerSpecYaml("This is a sample.", "/expectedOutput/swagger-swaggerreader.yaml");
-    }
-
-    private void executeAndAssertGeneratedSwaggerSpecJson(String description, String expectedOutput) throws MojoExecutionException, MojoFailureException, IOException {
-        mojo.execute();
-        assertGeneratedSwaggerSpecJson(description, expectedOutput, "swagger.json");
-    }
-
-    private void assertGeneratedSwaggerSpecJson(String description, String expectedOutput, String generatedFileName) throws IOException {
-        JsonNode actualJson = mapper.readTree(new File(swaggerOutputDir, generatedFileName));
-        JsonNode expectJson = mapper.readTree(this.getClass().getResourceAsStream(expectedOutput));
-
-        changeDescription(expectJson, description);
-        assertJsonEquals(expectJson, actualJson, Configuration.empty().when(IGNORING_ARRAY_ORDER));
-    }
-
-    private void assertGeneratedSwaggerSpecYaml(String description, String expectedOutput) throws MojoExecutionException, MojoFailureException, IOException {
         mojo.getApiSources().get(0).setOutputFormats("yaml");
         mojo.execute();
 
         String actualYaml = io.swagger.util.Yaml.pretty().writeValueAsString(
                 new Yaml().load(FileUtils.readFileToString(new File(swaggerOutputDir, "swagger.yaml"))));
         String expectYaml = io.swagger.util.Yaml.pretty().writeValueAsString(
-                new Yaml().load(this.getClass().getResourceAsStream(expectedOutput)));
+                new Yaml().load(this.getClass().getResourceAsStream("/expectedOutput/swagger-swaggerreader.yaml")));
 
         JsonNode actualJson = mapper.readTree(YamlToJson(actualYaml));
         JsonNode expectJson = mapper.readTree(YamlToJson(expectYaml));
 
-        changeDescription(expectJson, description);
+        changeDescription(expectJson, "This is a sample.");
         assertJsonEquals(expectJson, actualJson, Configuration.empty().when(IGNORING_ARRAY_ORDER));
     }
+
 }

--- a/src/test/java/com/github/kongchen/swagger/docgen/reader/JaxrsReaderTest.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/reader/JaxrsReaderTest.java
@@ -7,112 +7,122 @@ import static org.testng.Assert.assertTrue;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.jaxrs.ext.SwaggerExtension;
+import io.swagger.jaxrs.ext.SwaggerExtensions;
 import io.swagger.models.Swagger;
 import io.swagger.models.Tag;
 import io.swagger.models.parameters.Parameter;
 import org.apache.maven.plugin.logging.Log;
 
 import org.mockito.Mock;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 
 public class JaxrsReaderTest {
-  @Mock
-  private Log log;
+    @Mock
+    private Log log;
 
-  private JaxrsReader reader;
+    private JaxrsReader reader;
 
-  @BeforeMethod
-  public void setup() {
-    Swagger swagger = new Swagger();
-    reader = new JaxrsReader(swagger, log);
-  }
+    List<SwaggerExtension> extensions = SwaggerExtensions.getExtensions();
 
-  @Test
-  public void ignoreClassIfNoApiAnnotation() {
-    Swagger result = reader.read(NotAnnotatedApi.class);
-
-    assertEmptySwaggerResponse(result);
-  }
-
-  @Test
-  public void ignoreApiIfHiddenAttributeIsTrue() {
-    Swagger result = reader.read(HiddenApi.class);
-
-    assertEmptySwaggerResponse(result);
-  }
-
-  @Test
-  public void includeApiIfHiddenParameterIsTrueAndApiHiddenAttributeIsTrue() {
-    Swagger result = reader.read(HiddenApi.class, "", null, true, new String[0], new String[0], new HashMap<String, Tag>(), new ArrayList<Parameter>());
-
-    assertNotNull(result, "No Swagger object created");
-    assertFalse(result.getTags().isEmpty(), "Should contain api tags");
-    assertFalse(result.getPaths().isEmpty(), "Should contain operation paths");
-  }
-
-  @Test
-  public void discoverApiOperation() {
-    Tag expectedTag = new Tag();
-    expectedTag.name("atag");
-    Swagger result = reader.read(AnApi.class);
-
-    assertSwaggerResponseContents(expectedTag, result);
-  }
-
-  @Test
-  public void createNewSwaggerInstanceIfNoneProvided() {
-    JaxrsReader nullReader = new JaxrsReader(null, log);
-    Tag expectedTag = new Tag();
-    expectedTag.name("atag");
-    Swagger result = nullReader.read(AnApi.class);
-
-    assertSwaggerResponseContents(expectedTag, result);
-  }
-
-  private void assertEmptySwaggerResponse(Swagger result) {
-    assertNotNull(result, "No Swagger object created");
-    assertNull(result.getTags(), "Should not have any tags");
-    assertNull(result.getPaths(), "Should not have any paths");
-  }
-
-  private void assertSwaggerResponseContents(Tag expectedTag, Swagger result) {
-    assertNotNull(result, "No Swagger object created");
-    assertFalse(result.getTags().isEmpty(), "Should contain api tags");
-    assertTrue(result.getTags().contains(expectedTag), "Expected tag missing");
-    assertFalse(result.getPaths().isEmpty(), "Should contain operation paths");
-    assertTrue(result.getPaths().containsKey("/apath"), "Path missing from paths map");
-    io.swagger.models.Path path = result.getPaths().get("/apath");
-    assertFalse(path.getOperations().isEmpty(), "Should be a get operation");
-  }
-
-  @Api(tags = "atag")
-  @Path("/apath")
-  static class AnApi {
-    @ApiOperation(value = "Get a model.")
-    @GET
-    public Response getOperation() {
-      return Response.ok().build();
+    @BeforeMethod
+    public void setup() {
+        reader = new JaxrsReader(new Swagger(), log);
     }
-  }
 
-  @Api(hidden = true, tags = "atag")
-  @Path("/hidden/path")
-  static class HiddenApi {
-    @ApiOperation(value = "Get a model.")
-    @GET
-    public Response getOperation() {
-      return Response.ok().build();
+    @AfterMethod
+    public void resetExtenstions() {
+        SwaggerExtensions.setExtensions(extensions);
     }
-  }
 
-  @Path("/apath")
-  static class NotAnnotatedApi {
-  }
+    @Test
+    public void ignoreClassIfNoApiAnnotation() {
+        Swagger result = reader.read(NotAnnotatedApi.class);
+
+        assertEmptySwaggerResponse(result);
+    }
+
+    @Test
+    public void ignoreApiIfHiddenAttributeIsTrue() {
+        Swagger result = reader.read(HiddenApi.class);
+
+        assertEmptySwaggerResponse(result);
+    }
+
+    @Test
+    public void includeApiIfHiddenParameterIsTrueAndApiHiddenAttributeIsTrue() {
+        Swagger result = reader.read(HiddenApi.class, "", null, true, new String[0], new String[0], new HashMap<String, Tag>(), new ArrayList<Parameter>());
+
+        assertNotNull(result, "No Swagger object created");
+        assertFalse(result.getTags().isEmpty(), "Should contain api tags");
+        assertFalse(result.getPaths().isEmpty(), "Should contain operation paths");
+    }
+
+    @Test
+    public void discoverApiOperation() {
+        Tag expectedTag = new Tag();
+        expectedTag.name("atag");
+        Swagger result = reader.read(AnApi.class);
+
+        assertSwaggerResponseContents(expectedTag, result);
+    }
+
+    @Test
+    public void createNewSwaggerInstanceIfNoneProvided() {
+        JaxrsReader nullReader = new JaxrsReader(null, log);
+        Tag expectedTag = new Tag();
+        expectedTag.name("atag");
+        Swagger result = nullReader.read(AnApi.class);
+
+        assertSwaggerResponseContents(expectedTag, result);
+    }
+
+    private void assertEmptySwaggerResponse(Swagger result) {
+        assertNotNull(result, "No Swagger object created");
+        assertNull(result.getTags(), "Should not have any tags");
+        assertNull(result.getPaths(), "Should not have any paths");
+    }
+
+    private void assertSwaggerResponseContents(Tag expectedTag, Swagger result) {
+        assertNotNull(result, "No Swagger object created");
+        assertFalse(result.getTags().isEmpty(), "Should contain api tags");
+        assertTrue(result.getTags().contains(expectedTag), "Expected tag missing");
+        assertFalse(result.getPaths().isEmpty(), "Should contain operation paths");
+        assertTrue(result.getPaths().containsKey("/apath"), "Path missing from paths map");
+        io.swagger.models.Path path = result.getPaths().get("/apath");
+        assertFalse(path.getOperations().isEmpty(), "Should be a get operation");
+    }
+
+    @Api(tags = "atag")
+    @Path("/apath")
+    static class AnApi {
+        @ApiOperation(value = "Get a model.")
+        @GET
+        public Response getOperation() {
+            return Response.ok().build();
+        }
+    }
+
+    @Api(hidden = true, tags = "atag")
+    @Path("/hidden/path")
+    static class HiddenApi {
+        @ApiOperation(value = "Get a model.")
+        @GET
+        public Response getOperation() {
+            return Response.ok().build();
+        }
+    }
+
+    @Path("/apath")
+    static class NotAnnotatedApi {
+    }
 }


### PR DESCRIPTION
`JaxRsReader` overrides state of `SwaggerExtensions` when created. While it's not a big problem at runtime (because you don't need to create both JaxRs and Spring readers usually), it brakes tests. So does this commit https://github.com/kongchen/swagger-maven-plugin/commit/b5a7c74639f21f28fa389467ba82754406c88ad8