### PR TITLE
added plain old Servlet support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,15 @@
             <name>Andrew B</name>
         </developer>
     </developers>
+    <contributors>
+        <contributor>
+            <email>stripodi@adobe.com</email>
+            <name>Simone Tripodi</name>
+            <organization>Adobe Research (Schweiz) AG</organization>
+            <organizationUrl>http://www.adobe.com/</organizationUrl>
+            <timezone>+1</timezone>
+        </contributor>
+    </contributors>
 
     <properties>
         <maven.version>2.2.1</maven.version>
@@ -103,6 +112,11 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-jaxrs</artifactId>
+            <version>${swagger.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-servlet</artifactId>
             <version>${swagger.version}</version>
         </dependency>
         <dependency>

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/ServletReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/ServletReader.java
@@ -1,0 +1,27 @@
+package com.github.kongchen.swagger.docgen.reader;
+
+import java.util.Set;
+
+import org.apache.maven.plugin.logging.Log;
+
+import com.github.kongchen.swagger.docgen.GenerateException;
+
+import io.swagger.models.Swagger;
+import io.swagger.servlet.Reader;
+
+/**
+ * A dedicated {@link ClassSwaggerReader} to scan Serlet classes.
+ */
+public class ServletReader extends AbstractReader implements ClassSwaggerReader {
+
+    public ServletReader(Swagger swagger, Log LOG) {
+        super(swagger, LOG);
+    }
+
+    @Override
+    public Swagger read(Set<Class<?>> classes) throws GenerateException {
+        Reader.read(swagger, classes );
+        return swagger;
+    }
+
+}


### PR DESCRIPTION
with the proposed few minor additions, the swagger-maven-plugin is now able to generate at compile time the APIs documentation for Servlets, it would be great to have it supported by default in the plugin rather than making people implementing their own solution every time.