### PR TITLE
Methods with generics have no parameters

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
@@ -60,17 +60,17 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
     private static final String CLASS_NAME_PREFIX = "class ";
     private static final String INTERFACE_NAME_PREFIX = "interface ";
 
-    public JaxrsReader(Swagger swagger, Log LOG) {
+  public JaxrsReader(Swagger swagger, Log LOG) {
         super(swagger, LOG);
     }
 
     @Override
     protected void updateExtensionChain() {
-        List<SwaggerExtension> extensions = new ArrayList<SwaggerExtension>();
-        extensions.add(new BeanParamInjectParamExtention());
+    	List<SwaggerExtension> extensions = new ArrayList<SwaggerExtension>();
+    	extensions.add(new BeanParamInjectParamExtention());
         extensions.add(new SwaggerJerseyJaxrs());
         extensions.add(new JaxrsParameterExtension());
-        SwaggerExtensions.setExtensions(extensions);
+    	SwaggerExtensions.setExtensions(extensions);
     }
 
     @Override
@@ -184,14 +184,14 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
 
     private Map<String, Tag> scanClasspathForTags() {
         Map<String, Tag> tags = new HashMap<String, Tag>();
-        for (Class<?> aClass : new Reflections("").getTypesAnnotatedWith(SwaggerDefinition.class)) {
+        for (Class<?> aClass: new Reflections("").getTypesAnnotatedWith(SwaggerDefinition.class)) {
             SwaggerDefinition swaggerDefinition = AnnotationUtils.findAnnotation(aClass, SwaggerDefinition.class);
 
             for (io.swagger.annotations.Tag tag : swaggerDefinition.tags()) {
 
                 String tagName = tag.name();
                 if (!tagName.isEmpty()) {
-                    tags.put(tag.name(), new Tag().name(tag.name()).description(tag.description()));
+                  tags.put(tag.name(), new Tag().name(tag.name()).description(tag.description()));
                 }
             }
         }
@@ -419,59 +419,59 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
         return operation;
     }
 
-    private Class<?> convertToClass(Type type) {
-        Type typeToConvert = type;
-        if (type instanceof ParameterizedType) {
-            typeToConvert = ((ParameterizedType) type).getRawType();
-        }
-        try {
-            return Class.forName(getClassName(typeToConvert));
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-    }
+	private Class<?> convertToClass(Type type) {
+		Type typeToConvert = type;
+		if (type instanceof ParameterizedType) {
+			typeToConvert = ((ParameterizedType) type).getRawType();
+		}
+		try {
+			return Class.forName(getClassName(typeToConvert));
+		} catch (ClassNotFoundException e) {
+			throw new RuntimeException(e);
+		}
+	}
 
-    private static String getClassName(Type type) {
-        String fullName = type.toString();
-        if (fullName.startsWith(CLASS_NAME_PREFIX)) {
-            return fullName.substring(CLASS_NAME_PREFIX.length());
-        } else if (fullName.startsWith(INTERFACE_NAME_PREFIX)) {
-            return fullName.substring(INTERFACE_NAME_PREFIX.length());
-        }
-        return fullName;
-    }
+	private static String getClassName(Type type) {
+		String fullName = type.toString();
+		if (fullName.startsWith(CLASS_NAME_PREFIX)) {
+			return fullName.substring(CLASS_NAME_PREFIX.length());
+		} else if (fullName.startsWith(INTERFACE_NAME_PREFIX)) {
+			return fullName.substring(INTERFACE_NAME_PREFIX.length());
+		}
+		return fullName;
+	}
 
-    private Annotation[][] findParamAnnotations(Method method) {
-        Annotation[][] paramAnnotation = method.getParameterAnnotations();
+	private Annotation[][] findParamAnnotations(Method method) {
+		Annotation[][] paramAnnotation = method.getParameterAnnotations();
 
-        Method overriddenMethod = ReflectionUtils.getOverriddenMethod(method);
-        while (overriddenMethod != null) {
-            paramAnnotation = merge(overriddenMethod.getParameterAnnotations(), paramAnnotation);
-            overriddenMethod = ReflectionUtils.getOverriddenMethod(overriddenMethod);
-        }
-        return paramAnnotation;
-    }
+		Method overriddenMethod = ReflectionUtils.getOverriddenMethod(method);
+		while(overriddenMethod != null) {
+			paramAnnotation = merge(overriddenMethod.getParameterAnnotations(), paramAnnotation);
+			overriddenMethod = ReflectionUtils.getOverriddenMethod(overriddenMethod);
+		}
+		return paramAnnotation;
+	}
 
 
     private Annotation[][] merge(Annotation[][] overriddenMethodParamAnnotation,
-                                 Annotation[][] currentParamAnnotations) {
-        Annotation[][] mergedAnnotations = new Annotation[overriddenMethodParamAnnotation.length][];
+			Annotation[][] currentParamAnnotations) {
+    	Annotation[][] mergedAnnotations = new Annotation[overriddenMethodParamAnnotation.length][];
 
-        for (int i = 0; i < overriddenMethodParamAnnotation.length; i++) {
-            mergedAnnotations[i] = merge(overriddenMethodParamAnnotation[i], currentParamAnnotations[i]);
-        }
-        return mergedAnnotations;
-    }
+    	for(int i=0; i<overriddenMethodParamAnnotation.length; i++) {
+    		mergedAnnotations[i] = merge(overriddenMethodParamAnnotation[i], currentParamAnnotations[i]);
+    	}
+		return mergedAnnotations;
+	}
 
-    private Annotation[] merge(Annotation[] annotations,
-                               Annotation[] annotations2) {
-        List<Annotation> mergedAnnotations = new ArrayList<Annotation>();
-        mergedAnnotations.addAll(Arrays.asList(annotations));
-        mergedAnnotations.addAll(Arrays.asList(annotations2));
-        return mergedAnnotations.toArray(new Annotation[0]);
-    }
+	private Annotation[] merge(Annotation[] annotations,
+			Annotation[] annotations2) {
+		List<Annotation> mergedAnnotations = new ArrayList<Annotation>();
+		mergedAnnotations.addAll(Arrays.asList(annotations));
+		mergedAnnotations.addAll(Arrays.asList(annotations2));
+		return mergedAnnotations.toArray(new Annotation[0]);
+	}
 
-    public String extractOperationMethod(ApiOperation apiOperation, Method method, Iterator<SwaggerExtension> chain) {
+	public String extractOperationMethod(ApiOperation apiOperation, Method method, Iterator<SwaggerExtension> chain) {
         if (apiOperation != null && !apiOperation.httpMethod().isEmpty()) {
             return apiOperation.httpMethod().toLowerCase();
         } else if (AnnotationUtils.findAnnotation(method, GET.class) != null) {

--- a/src/test/java/com/wordnik/jaxrs/MyResource.java
+++ b/src/test/java/com/wordnik/jaxrs/MyResource.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 @Api(description = "Operations about pets")
 @Produces({"application/json", "application/xml"})
-public interface MyResource {
+public interface MyResource<T> {
 
 	//contrived example test case for swagger-maven-plugin issue #358
 	@GET
@@ -45,4 +45,5 @@ public interface MyResource {
             @PathParam("secondParamInterface") String secondParam,
             @QueryParam("thirdParamInterface") String thirdParam);
 
+    Response insertResource(T resource);
 }

--- a/src/test/java/com/wordnik/jaxrs/MyResourceAbstract.java
+++ b/src/test/java/com/wordnik/jaxrs/MyResourceAbstract.java
@@ -12,7 +12,7 @@ import java.util.List;
 /**
  * @author daniele.orler
  */
-public abstract class MyResourceAbstract implements MyResource {
+public abstract class MyResourceAbstract<T> implements MyResource<T> {
     @Override
     public abstract Response getPetsById(Long startId, Long endId) throws NotFoundException;
 

--- a/src/test/java/com/wordnik/jaxrs/MyResourceImpl.java
+++ b/src/test/java/com/wordnik/jaxrs/MyResourceImpl.java
@@ -20,15 +20,18 @@ import com.wordnik.sample.JavaRestResourceUtil;
 import com.wordnik.sample.data.PetData;
 import com.wordnik.sample.model.ListItem;
 import com.wordnik.sample.model.Pet;
-
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import java.util.ArrayList;
+import java.util.List;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Response;
-import java.util.ArrayList;
-import java.util.List;
 
 @Path("/myResourceImpl")
-public class MyResourceImpl extends MyResourceAbstract {
+public class MyResourceImpl extends MyResourceAbstract<String> {
     static PetData petData = new PetData();
     static JavaRestResourceUtil ru = new JavaRestResourceUtil();
 
@@ -49,7 +52,7 @@ public class MyResourceImpl extends MyResourceAbstract {
 
     //contrived example test case for swagger-maven-plugin issue #505
     /* (non-Javadoc)
-	 * @see com.wordnik.jaxrs.MyResource#getListOfItems()
+     * @see com.wordnik.jaxrs.MyResource#getListOfItems()
 	 */
     @Path("list")
     @Override
@@ -67,6 +70,13 @@ public class MyResourceImpl extends MyResourceAbstract {
             @PathParam("firstParamConcrete") String firstParam,
             String secondParam,
             String thirdParam) {
+        return Response.ok().build();
+    }
+
+    @POST
+    @ApiOperation(value = "Insert a response", notes = "This is a contrived example")
+    @Override
+    public Response insertResource(@ApiParam(value = "Resource to insert", required = true) String resource) {
         return Response.ok().build();
     }
 }

--- a/src/test/java/com/wordnik/jaxrs/MyResourceImpl.java
+++ b/src/test/java/com/wordnik/jaxrs/MyResourceImpl.java
@@ -20,15 +20,15 @@ import com.wordnik.sample.JavaRestResourceUtil;
 import com.wordnik.sample.data.PetData;
 import com.wordnik.sample.model.ListItem;
 import com.wordnik.sample.model.Pet;
+
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
-import java.util.ArrayList;
-import java.util.List;
 import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.List;
 
 @Path("/myResourceImpl")
 public class MyResourceImpl extends MyResourceAbstract<String> {
@@ -52,7 +52,7 @@ public class MyResourceImpl extends MyResourceAbstract<String> {
 
     //contrived example test case for swagger-maven-plugin issue #505
     /* (non-Javadoc)
-     * @see com.wordnik.jaxrs.MyResource#getListOfItems()
+	 * @see com.wordnik.jaxrs.MyResource#getListOfItems()
 	 */
     @Path("list")
     @Override

--- a/src/test/resources/expectedOutput/swagger-swaggerreader.json
+++ b/src/test/resources/expectedOutput/swagger-swaggerreader.json
@@ -81,7 +81,26 @@
             "description" : "Pet not found"
           }
         }
-      }
+      },
+      "post" : {
+        "summary" : "Insert a response",
+        "description" : "This is a contrived example",
+        "operationId" : "insertResource",
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "body",
+          "description" : "Resource to insert",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+            }
+        } ],
+        "responses" : {
+          "default" : {
+            "description" : "successful operation"
+            }
+          }
+        }
     },
     "/myResourceImpl/list" : {
       "get" : {

--- a/src/test/resources/expectedOutput/swagger-swaggerreader.yaml
+++ b/src/test/resources/expectedOutput/swagger-swaggerreader.yaml
@@ -63,6 +63,20 @@ paths:
           description: "Invalid ID supplied"
         404:
           description: "Pet not found"
+    post:
+      summary: "Insert a response"
+      description: "This is a contrived example"
+      operationId: "insertResource"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "Resource to insert"
+        required: true
+        schema:
+          type: "string"
+      responses:
+        default:
+          description: "successful operation"
   /myResourceImpl/list:
     get:
       summary: "Get a list of items"

--- a/src/test/resources/expectedOutput/swagger-with-converter.json
+++ b/src/test/resources/expectedOutput/swagger-with-converter.json
@@ -89,6 +89,26 @@
             "description" : "Pet not found"
           }
         }
+      },
+      "post" : {
+        "summary" : "Insert a response",
+        "description" : "This is a contrived example",
+        "operationId" : "insertResource",
+        "produces" : [ "application/xml", "application/json" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "body",
+          "description" : "Resource to insert",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+            }
+          } ],
+        "responses" : {
+          "default" : {
+            "description" : "successful operation"
+          }
+        }
       }
     },
     "/myResourceImpl/list" : {

--- a/src/test/resources/expectedOutput/swagger-with-converter.yaml
+++ b/src/test/resources/expectedOutput/swagger-with-converter.yaml
@@ -68,6 +68,23 @@ paths:
           description: "Invalid ID supplied"
         404:
           description: "Pet not found"
+    post:
+      summary: "Insert a response"
+      description: "This is a contrived example"
+      operationId: "insertResource"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "Resource to insert"
+        required: true
+        schema:
+          type: "string"
+      responses:
+        default:
+          description: "successful operation"
   /myResourceImpl/list:
     get:
       summary: "Get a list of items"

--- a/src/test/resources/expectedOutput/swagger.json
+++ b/src/test/resources/expectedOutput/swagger.json
@@ -89,6 +89,26 @@
             "description" : "Pet not found"
           }
         }
+      },
+    "post" : {
+      "summary" : "Insert a response",
+      "description" : "This is a contrived example",
+      "operationId" : "insertResource",
+      "produces" : [ "application/xml", "application/json" ],
+      "parameters" : [ {
+        "in" : "body",
+        "name" : "body",
+        "description" : "Resource to insert",
+        "required" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      } ],
+      "responses" : {
+        "default" : {
+          "description" : "successful operation"
+          }
+        }
       }
     },
     "/myResourceImpl/list" : {

--- a/src/test/resources/expectedOutput/swagger.yaml
+++ b/src/test/resources/expectedOutput/swagger.yaml
@@ -68,6 +68,23 @@ paths:
           description: "Invalid ID supplied"
         404:
           description: "Pet not found"
+    post:
+      summary: "Insert a response"
+      description: "This is a contrived example"
+      operationId: "insertResource"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "Resource to insert"
+        required: true
+        schema:
+          type: "string"
+      responses:
+        default:
+          description: "successful operation"
   /myResourceImpl/list:
     get:
       summary: "Get a list of items"

--- a/src/test/resources/sample.html
+++ b/src/test/resources/sample.html
@@ -281,6 +281,68 @@ This is a contrived example
 
 
 
+### POST
+
+
+<a id="insertResource">Insert a response</a>
+
+This is a contrived example
+
+
+
+
+
+
+
+#### Request
+
+
+
+##### Parameters
+
+<table border="1">
+    <tr>
+        <th>Name</th>
+        <th>Located in</th>
+        <th>Required</th>
+        <th>Description</th>
+        <th>Default</th>
+        <th>Schema</th>
+    </tr>
+
+
+
+    <tr>
+        <th>body</th>
+        <td>body</td>
+        <td>yes</td>
+        <td>Resource to insert</td>
+        <td> - </td>
+
+        <td>
+
+
+        </td>
+
+    </tr>
+
+
+</table>
+
+
+
+#### Response
+
+**Content-Type: ** application/json, application/xml
+
+
+| Status Code | Reason      | Response Model |
+|-------------|-------------|----------------|
+| default    | successful operation |  - |
+
+
+
+
 
 
 
@@ -2655,9 +2717,9 @@ For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values w
     <td></td>
     <td> - </td>
 
-    
+
             <td>string </td>
-    
+
 
 </tr>
 
@@ -2732,9 +2794,9 @@ For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values w
     <td></td>
     <td> - </td>
 
-    
+
             <td>string </td>
-    
+
 
 </tr>
 


### PR DESCRIPTION
We have the following case:

`public interface A<T> {`
 `void post(T parameter);`
`}`

`public class B implements A<String> {`
`@POST`
`@ApiOperation`
`void post(@ApiParameter String parameter) {`
`// do something`
`}`

In generated swagger files method "post" has no parameters. This happens due to the bridge method with the same name generated by java. The order in which the methods are parsed is important. To reproduce this issue the bridge method should be parsed after the declared one (if the order is different, the parameters are available in swagger files). However the methods returned by .getMethods() call are not sorted and are not in any particular order. To fix the issue I excluded bridge methods from parsing.



