### PR TITLE
Added support for generic operations defined in parent controllers

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiReader.java
@@ -283,6 +283,10 @@ public class SpringMvcApiReader extends AbstractReader implements ClassSwaggerRe
             }
         }
 
+        if (!genericTypeMap.isEmpty()) {
+            operationId += ((Class) genericTypeMap.values().iterator().next()).getSimpleName();
+        }
+
         operation.operationId(operationId);
 
         for (String str : requestMapping.produces()) {

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiReader.java
@@ -19,12 +19,14 @@ import io.swagger.models.SecurityRequirement;
 import io.swagger.models.Swagger;
 import io.swagger.models.Tag;
 import io.swagger.models.parameters.Parameter;
+import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.RefProperty;
 import org.apache.maven.plugin.logging.Log;
 import org.codehaus.plexus.util.StringUtils;
 import org.springframework.core.DefaultParameterNameDiscoverer;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.CollectionUtils;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -128,7 +130,7 @@ public class SpringMvcApiReader extends AbstractReader implements ClassSwaggerRe
                 //http method
                 for (RequestMethod requestMethod : requestMapping.method()) {
                     String httpMethod = requestMethod.toString().toLowerCase();
-                    Operation operation = parseMethod(method);
+                    Operation operation = parseMethod(method, controller);
 
                     updateOperationParameters(new ArrayList<Parameter>(), regexMap, operation);
 
@@ -152,7 +154,7 @@ public class SpringMvcApiReader extends AbstractReader implements ClassSwaggerRe
         return swagger;
     }
 
-    private Operation parseMethod(Method method) {
+    private Operation parseMethod(Method method, Class<?> controller) {
         int responseCode = 200;
         Operation operation = new Operation();
 
@@ -163,6 +165,8 @@ public class SpringMvcApiReader extends AbstractReader implements ClassSwaggerRe
         String responseContainer = null;
         String operationId = method.getName();
         Map<String, Property> defaultResponseHeaders = null;
+
+        Map<Type, Type> genericTypeMap = getGenericTypeMap(method, controller);
 
         ApiOperation apiOperation = findMergedAnnotation(method, ApiOperation.class);
 
@@ -229,6 +233,10 @@ public class SpringMvcApiReader extends AbstractReader implements ClassSwaggerRe
         if (responseClass instanceof ParameterizedType && ResponseEntity.class.equals(((ParameterizedType) responseClass).getRawType())) {
             responseClass = ((ParameterizedType) responseClass).getActualTypeArguments()[0];
         }
+        if (genericTypeMap.containsKey(responseClass)) {
+            responseClass = genericTypeMap.get(responseClass);
+        }
+
         boolean hasApiAnnotation = false;
         if (responseClass instanceof Class) {
             hasApiAnnotation = findAnnotation((Class) responseClass, Api.class) != null;
@@ -239,7 +247,12 @@ public class SpringMvcApiReader extends AbstractReader implements ClassSwaggerRe
                 && !hasApiAnnotation) {
             if (isPrimitive(responseClass)) {
                 Property property = ModelConverters.getInstance().readAsProperty(responseClass);
+
                 if (property != null) {
+                    if (property instanceof ArrayProperty) {
+                        solveGenericTypes((ArrayProperty) property, genericTypeMap, responseClass);
+                    }
+
                     Property responseProperty = RESPONSE_CONTAINER_CONVERTER.withResponseContainer(responseContainer, property);
                     operation.response(responseCode, new Response()
                             .description("successful operation")
@@ -316,6 +329,11 @@ public class SpringMvcApiReader extends AbstractReader implements ClassSwaggerRe
         // genericParamTypes = method.getGenericParameterTypes
         for (int i = 0; i < parameterTypes.length; i++) {
             Type type = genericParameterTypes[i];
+
+            if (genericTypeMap.containsKey(type)) {
+                type = genericTypeMap.get(type);
+            }
+
             List<Annotation> annotations = Arrays.asList(paramAnnotations[i]);
             List<Parameter> parameters = getParameters(type, annotations);
 
@@ -337,6 +355,55 @@ public class SpringMvcApiReader extends AbstractReader implements ClassSwaggerRe
         processOperationDecorator(operation, method);
 
         return operation;
+    }
+
+    /**
+     * Swaps generic items in ArrayProperties to concrete type Properties
+     */
+    private void solveGenericTypes(ArrayProperty property, Map<Type, Type> genericTypeMap, Type type) {
+        if (property != null && !CollectionUtils.isEmpty(genericTypeMap) && type instanceof ParameterizedType) {
+            Type actualType = ((ParameterizedType) type).getActualTypeArguments()[0];
+
+            if (genericTypeMap.containsKey(actualType)) {
+                actualType = genericTypeMap.get(actualType);
+                Property prop = ModelConverters.getInstance().readAsProperty(actualType);
+
+                if (prop instanceof ArrayProperty) {
+                    solveGenericTypes((ArrayProperty) prop, genericTypeMap, actualType);
+                }
+                property.setItems(prop);
+            }
+        }
+    }
+
+    /**
+     * Creates a map linking class generic types to actual parameter types
+     *
+     * @param method        Parsed method
+     * @param controller    Controller containing the specified method
+     *
+     * @return  A map of concrete types indexed by their matching generic type parameter
+     */
+    private Map<Type, Type> getGenericTypeMap(Method method, Class<?> controller) {
+        Type[] types = method.getDeclaringClass().getTypeParameters();
+        Map<Type, Type> genericTypeMap = new HashMap<Type, Type>(types.length);
+
+        if (types.length > 0 && method.getDeclaringClass().equals(controller.getSuperclass())) {
+            Type[] actualTypes;
+
+            if (controller.getGenericSuperclass() instanceof ParameterizedType) {
+                actualTypes = ((ParameterizedType) controller.getGenericSuperclass()).getActualTypeArguments();
+            } else {
+                actualTypes = new Type[0];
+            }
+
+            if (types.length == actualTypes.length) {
+                for (int i = 0; i < types.length; i++) {
+                    genericTypeMap.put(types[i], actualTypes[i]);
+                }
+            }
+        }
+        return genericTypeMap;
     }
 
     private Map<String, List<Method>> collectApisByRequestMapping(List<Method> methods) {

--- a/src/test/java/com/wordnik/jaxrs/MyResourceImpl.java
+++ b/src/test/java/com/wordnik/jaxrs/MyResourceImpl.java
@@ -20,9 +20,9 @@ import com.wordnik.sample.JavaRestResourceUtil;
 import com.wordnik.sample.data.PetData;
 import com.wordnik.sample.model.ListItem;
 import com.wordnik.sample.model.Pet;
-
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -42,7 +42,7 @@ public class MyResourceImpl extends MyResourceAbstract<String> {
     @Override
     public Response getPetsById(Long startId, Long endId)
             throws com.wordnik.sample.exception.NotFoundException {
-        Pet pet = petData.getPetbyId(startId);
+        Pet pet = petData.get(startId);
         if (pet != null) {
             return Response.ok().entity(pet).build();
         } else {

--- a/src/test/java/com/wordnik/jaxrs/PetResource.java
+++ b/src/test/java/com/wordnik/jaxrs/PetResource.java
@@ -61,7 +61,6 @@ import javax.ws.rs.core.Response;
 @Produces({"application/json", "application/xml"})
 public class PetResource {
     static PetData petData = new PetData();
-    static JavaRestResourceUtil ru = new JavaRestResourceUtil();
 
     @GET
     @Path("/{petId : [0-9]}")
@@ -75,7 +74,7 @@ public class PetResource {
     public Response getPetById(
             @ApiParam(value = "ID of pet that needs to be fetched", allowableValues = "range[1,5]", required = true) @PathParam("petId") Long petId)
             throws com.wordnik.sample.exception.NotFoundException {
-        Pet pet = petData.getPetbyId(petId);
+        Pet pet = petData.get(petId);
         if (pet != null) {
             return Response.ok().entity(pet).build();
         } else {
@@ -96,7 +95,7 @@ public class PetResource {
             @ApiParam(value = "start ID of pets that need to be fetched", allowableValues = "range[1,99]", required = true) @PathParam("startId") Long startId,
             @ApiParam(value = "end ID of pets that need to be fetched", allowableValues = "range[1,99]", required = true) @PathParam("endId") Long endId)
             throws com.wordnik.sample.exception.NotFoundException {
-        Pet pet = petData.getPetbyId(startId);
+        Pet pet = petData.get(startId);
         if (pet != null) {
             return Response.ok().entity(pet).build();
         } else {
@@ -111,7 +110,7 @@ public class PetResource {
     public Response deletePet(
             @ApiParam() @HeaderParam("api_key") String apiKey,
             @ApiParam(value = "Pet id to delete", required = true) @PathParam("petId") Long petId) {
-        petData.deletePet(petId);
+        petData.delete(petId);
         return Response.ok().build();
     }
 
@@ -121,7 +120,7 @@ public class PetResource {
     @ApiResponses(value = {@ApiResponse(code = 405, message = "Invalid input")})
     public Response addPet(
             @ApiParam(value = "Pet object that needs to be added to the store", required = true) Pet pet) {
-        Pet updatedPet = petData.addPet(pet);
+        Pet updatedPet = petData.save(pet);
         return Response.ok().entity(updatedPet).build();
     }
 
@@ -133,7 +132,7 @@ public class PetResource {
             @ApiResponse(code = 405, message = "Validation exception")})
     public Response updatePet(
             @ApiParam(value = "Pet object that needs to be added to the store", required = true) Pet pet) {
-        Pet updatedPet = petData.addPet(pet);
+        Pet updatedPet = petData.save(pet);
         return Response.ok().entity(updatedPet).build();
     }
 
@@ -147,7 +146,7 @@ public class PetResource {
     public Response findPetByPetName(
             @ApiParam(value = "petName", required = true)
             @PathParam("petName") PetName petName) {
-        return Response.ok(petData.getPetbyId(1)).build();
+        return Response.ok(petData.get(1)).build();
     }
 
     @GET
@@ -188,7 +187,7 @@ public class PetResource {
 	@ApiResponses(value = { @ApiResponse(code = 400, message = "Invalid page number value") })
 	public PagedList<Pet> findAllPaginated(
 			@ApiParam(value = "pageNumber", required = true) @QueryParam("pageNumber") int pageNumber) {
-		List<Pet> allPets = petData.findAllPets();
+		List<Pet> allPets = petData.getAll();
 		int pageSize = 5;
 		int startIndex = (pageNumber - 1) * pageSize;
 		int endIndex = startIndex + pageSize;

--- a/src/test/java/com/wordnik/sample/data/CrudService.java
+++ b/src/test/java/com/wordnik/sample/data/CrudService.java
@@ -1,0 +1,19 @@
+package com.wordnik.sample.data;
+
+import java.util.List;
+
+/**
+ * @author by amalagraba on 22/02/2018.
+ */
+public interface CrudService <E> {
+
+    void delete(long id);
+
+    E get(long id);
+
+    E update(E entity);
+
+    E save(E entity);
+
+    List<E> getAll();
+}

--- a/src/test/java/com/wordnik/sample/data/PetData.java
+++ b/src/test/java/com/wordnik/sample/data/PetData.java
@@ -26,7 +26,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class PetData {
+public class PetData implements CrudService<Pet> {
+
     static List<Pet> pets = new ArrayList<Pet>();
     static List<Category> categories = new ArrayList<Category>();
 
@@ -61,7 +62,7 @@ public class PetData {
                 "url1", "url2"}, new String[]{"tag3", "tag4"}, "available"));
     }
 
-    public Pet getPetbyId(long petId) {
+    public Pet get(long petId) {
         for (Pet pet : pets) {
             if (pet.getId().value() == petId) {
                 return pet;
@@ -70,7 +71,7 @@ public class PetData {
         return null;
     }
 
-    public void deletePet(long petId) {
+    public void delete(long petId) {
         if (!pets.isEmpty()) {
             for (int i = pets.size(); i >= 0; i++) {
                 Pet pet = pets.get(i);
@@ -111,11 +112,11 @@ public class PetData {
         return result;
     }
 
-	public List<Pet> findAllPets() {
+	public List<Pet> getAll() {
 		return Collections.unmodifiableList(pets);
 	}
 
-    public Pet addPet(Pet pet) {
+    public Pet save(Pet pet) {
         if (pet.getId().value() == 0) {
             long maxId = 0;
             for (int i = pets.size() - 1; i >= 0; i--) {
@@ -134,6 +135,10 @@ public class PetData {
         }
         pets.add(pet);
         return pet;
+    }
+
+    public Pet update(Pet pet) {
+        return save(pet);
     }
 
     static Pet createPet(long id, Category cat, String name, String[] urls,

--- a/src/test/java/com/wordnik/springmvc/CrudController.java
+++ b/src/test/java/com/wordnik/springmvc/CrudController.java
@@ -1,0 +1,88 @@
+package com.wordnik.springmvc;
+
+import com.wordnik.sample.data.CrudService;
+import com.wordnik.sample.exception.NotFoundException;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import javax.validation.constraints.Size;
+import java.util.List;
+
+/**
+ * @author by amalagraba on 22/02/2018.
+ */
+public abstract class CrudController<E> {
+
+    @GetMapping(value = "/")
+    @ApiOperation(value = "Returns all entities")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Entity data found"),
+            @ApiResponse(code = 400, message = "Invalid ID supplied"),
+            @ApiResponse(code = 404, message = "Entity not found")})
+    public ResponseEntity<List<E>> getAll() {
+        return ResponseEntity.ok(getCrudService().getAll());
+    }
+
+    @GetMapping(value = "/{id}")
+    @ApiOperation(value = "Find entity by ID",
+            notes = "Returns an entity when ID < 10.  ID > 10 or nonintegers will simulate API error conditions"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Entity data found"),
+            @ApiResponse(code = 400, message = "Invalid ID supplied"),
+            @ApiResponse(code = 404, message = "Entity not found")})
+    public ResponseEntity<E> get(
+            @ApiParam(value = "ID of the entity that needs to be fetched", allowableValues = "range[1,5]", required = true)
+            @PathVariable("id") Long id)
+            throws NotFoundException {
+        E entity = getCrudService().get(id);
+
+        if (entity != null) {
+            return ResponseEntity.ok(entity);
+        } else {
+            throw new NotFoundException(404, "Entity not found");
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    @ApiOperation(value = "Deletes an entity", nickname = "remove")
+    @ApiResponses(value = {@ApiResponse(code = 400, message = "Invalid entity value")})
+    public ResponseEntity delete(
+            @ApiParam(value = "Entity id to delete", required = true)
+            @PathVariable("id") @Size() Long id) {
+        getCrudService().delete(id);
+        return new ResponseEntity(HttpStatus.OK);
+    }
+
+    @PostMapping(consumes = {"application/json", "application/xml"})
+    @ApiOperation(value = "Add a new entity to the store")
+    @ApiResponses(value = {@ApiResponse(code = 405, message = "Invalid input")})
+    public ResponseEntity<E> save(
+            @ApiParam(value = "Entity object that needs to be added to the store", required = true)
+            @RequestBody E entity) {
+        return ResponseEntity.ok(getCrudService().save(entity));
+    }
+
+    @PutMapping(consumes = {"application/json", "application/xml"})
+    @ApiOperation(value = "Update an existing entity")
+    @ApiResponses(value = {@ApiResponse(code = 400, message = "Invalid ID supplied"),
+            @ApiResponse(code = 404, message = "Entity not found"),
+            @ApiResponse(code = 405, message = "Validation exception")})
+    public ResponseEntity<E> update(
+            @ApiParam(value = "Entity that needs to be updated", required = true)
+            @RequestBody E entity) {
+        return ResponseEntity.ok(getCrudService().update(entity));
+    }
+
+    protected abstract CrudService<E> getCrudService();
+}

--- a/src/test/resources/expectedOutput/swagger-spring.json
+++ b/src/test/resources/expectedOutput/swagger-spring.json
@@ -447,15 +447,15 @@
       },
       "post" : {
         "tags" : [ "pet" ],
-        "summary" : "Add a new pet to the store",
+        "summary" : "Add a new entity to the store",
         "description" : "",
-        "operationId" : "addPet",
+        "operationId" : "save",
         "consumes" : [ "application/xml", "application/json" ],
         "produces" : [ "application/xml", "application/json" ],
         "parameters" : [ {
           "in" : "body",
           "name" : "body",
-          "description" : "Pet object that needs to be added to the store",
+          "description" : "Entity object that needs to be added to the store",
           "required" : true,
           "schema" : {
             "$ref" : "#/definitions/Pet"
@@ -478,15 +478,15 @@
       },
       "put" : {
         "tags" : [ "pet" ],
-        "summary" : "Update an existing pet",
+        "summary" : "Update an existing entity",
         "description" : "",
-        "operationId" : "updatePet",
+        "operationId" : "update",
         "consumes" : [ "application/xml", "application/json" ],
         "produces" : [ "application/xml", "application/json" ],
         "parameters" : [ {
           "in" : "body",
           "name" : "body",
-          "description" : "Pet object that needs to be added to the store",
+          "description": "Entity that needs to be updated",
           "required" : true,
           "schema" : {
             "$ref" : "#/definitions/Pet"
@@ -503,7 +503,7 @@
             "description" : "Invalid ID supplied"
           },
           "404" : {
-            "description" : "Pet not found"
+            "description" : "Entity not found"
           },
           "405" : {
             "description" : "Validation exception"
@@ -512,6 +512,45 @@
         "security" : [ {
           "petstore_auth" : [ "write:pets", "read:pets" ]
         } ]
+      }
+    },
+    "/pet/": {
+      "get": {
+        "tags": [
+            "pet"
+        ],
+        "summary": "Returns all entities",
+        "description": "",
+        "operationId": "getAll",
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "Entity data found",
+            "schema": {
+              "type": "array",
+              "items": {
+              "$ref": "#/definitions/Pet"
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Entity not found"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
       }
     },
     "/pet/findByStatus" : {
@@ -923,43 +962,80 @@
         } ]
       }
     },
-    "/pet/{petId}" : {
-      "get" : {
-        "tags" : [ "pet" ],
-        "summary" : "Find pet by ID",
-        "description" : "Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions",
-        "operationId" : "getPetById",
-        "produces" : [ "application/xml", "application/json" ],
-        "parameters" : [ {
-          "name" : "petId",
-          "in" : "path",
-          "description" : "ID of pet that needs to be fetched",
-          "required" : true,
-          "type" : "integer",
-          "maximum" : 5,
-          "minimum" : 1,
-          "format" : "int64"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Pet data found",
-            "schema" : {
-              "$ref" : "#/definitions/Pet"
+    "/pet/{id}": {
+      "get": {
+        "tags": ["pet"],
+          "summary": "Find entity by ID",
+          "description": "Returns an entity when ID < 10.  ID > 10 or nonintegers will simulate API error conditions",
+          "operationId": "get",
+          "produces": [
+            "application/json",
+            "application/xml"
+          ],
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "ID of the entity that needs to be fetched",
+              "required": true,
+              "type": "integer",
+              "maximum": 5,
+              "minimum": 1,
+              "format": "int64"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Entity data found",
+              "schema": {
+                "$ref": "#/definitions/Pet"
+              }
+            },
+            "400": {
+              "description": "Invalid ID supplied"
+            },
+            "404": {
+              "description": "Entity not found"
             }
           },
-          "400" : {
-            "description" : "Invalid ID supplied"
-          },
-          "404" : {
-            "description" : "Pet not found"
+          "security" : [ {
+              "petstore_auth" : [ "write:pets", "read:pets" ]
+          } ]
+      },
+      "delete": {
+        "tags": [
+            "pet"
+        ],
+        "summary": "Deletes an entity",
+        "description": "",
+        "operationId": "remove",
+        "produces": [
+            "application/json",
+            "application/xml"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Entity id to delete",
+            "required": true,
+            "type": "integer",
+            "maximum": 2147483647,
+            "minimum": 0,
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid entity value"
           }
         },
-        "security" : [ {
-          "api_key" : [ ]
-        }, {
-          "petstore_auth" : [ "write:pets", "read:pets" ]
-        } ]
-      },
+          "security" : [ {
+              "petstore_auth" : [ "write:pets", "read:pets" ]
+          } ]
+      }
+    },
+    "/pet/{petId}" : {
       "post" : {
         "tags" : [ "pet" ],
         "summary" : "Updates a pet in the store with form data",
@@ -994,36 +1070,6 @@
           },
           "405" : {
             "description" : "Invalid input"
-          }
-        },
-        "security" : [ {
-          "petstore_auth" : [ "write:pets", "read:pets" ]
-        } ]
-      },
-      "delete" : {
-        "tags" : [ "pet" ],
-        "summary" : "Deletes a pet",
-        "description" : "",
-        "operationId" : "removePet",
-        "produces" : [ "application/xml", "application/json" ],
-        "parameters" : [ {
-          "name" : "api_key",
-          "in" : "header",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "petId",
-          "in" : "path",
-          "description" : "Pet id to delete",
-          "required" : true,
-          "type" : "integer",
-          "maximum" : 2147483647,
-          "minimum" : 0,
-          "format" : "int64"
-        } ],
-        "responses" : {
-          "400" : {
-            "description" : "Invalid pet value"
           }
         },
         "security" : [ {

--- a/src/test/resources/expectedOutput/swagger-spring.yaml
+++ b/src/test/resources/expectedOutput/swagger-spring.yaml
@@ -371,19 +371,19 @@ paths:
     post:
       tags:
       - "pet"
-      summary: "Add a new pet to the store"
+      summary: "Add a new entity to the store"
       description: ""
-      operationId: "addPet"
+      operationId: "save"
       consumes:
-      - "application/xml"
       - "application/json"
+      - "application/xml"
       produces:
-      - "application/xml"
       - "application/json"
+      - "application/xml"
       parameters:
       - in: "body"
         name: "body"
-        description: "Pet object that needs to be added to the store"
+        description: "Entity object that needs to be added to the store"
         required: true
         schema:
           $ref: "#/definitions/Pet"
@@ -401,19 +401,19 @@ paths:
     put:
       tags:
       - "pet"
-      summary: "Update an existing pet"
+      summary: "Update an existing entity"
       description: ""
-      operationId: "updatePet"
+      operationId: "update"
       consumes:
-      - "application/xml"
       - "application/json"
+      - "application/xml"
       produces:
-      - "application/xml"
       - "application/json"
+      - "application/xml"
       parameters:
       - in: "body"
         name: "body"
-        description: "Pet object that needs to be added to the store"
+        description: "Entity that needs to be updated"
         required: true
         schema:
           $ref: "#/definitions/Pet"
@@ -425,9 +425,35 @@ paths:
         400:
           description: "Invalid ID supplied"
         404:
-          description: "Pet not found"
+          description: "Entity not found"
         405:
           description: "Validation exception"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+  /pet/:
+    get:
+      tags:
+      - "pet"
+      summary: "Returns all entities"
+      description: ""
+      operationId: "getAll"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters: []
+      responses:
+        200:
+          description: "Entity data found"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Pet"
+        400:
+          description: "Invalid ID supplied"
+        404:
+          description: "Entity not found"
       security:
       - petstore_auth:
         - "write:pets"
@@ -809,40 +835,65 @@ paths:
       - petstore_auth:
         - "write:pets"
         - "read:pets"
-  /pet/{petId}:
+  /pet/{id}:
     get:
       tags:
       - "pet"
-      summary: "Find pet by ID"
-      description: "Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate\
+      summary: "Find entity by ID"
+      description: "Returns an entity when ID < 10.  ID > 10 or nonintegers will simulate\
         \ API error conditions"
-      operationId: "getPetById"
+      operationId: "get"
       produces:
-      - "application/xml"
       - "application/json"
+      - "application/xml"
       parameters:
-      - name: "petId"
+      - name: "id"
         in: "path"
-        description: "ID of pet that needs to be fetched"
+        description: "ID of the entity that needs to be fetched"
         required: true
         type: "integer"
-        maximum: 5.0
-        minimum: 1.0
+        maximum: 5
+        minimum: 1
         format: "int64"
       responses:
         200:
-          description: "Pet data found"
+          description: "Entity data found"
           schema:
             $ref: "#/definitions/Pet"
         400:
           description: "Invalid ID supplied"
         404:
-          description: "Pet not found"
+          description: "Entity not found"
       security:
-      - api_key: []
       - petstore_auth:
         - "write:pets"
         - "read:pets"
+    delete:
+      tags:
+      - "pet"
+      summary: "Deletes an entity"
+      description: ""
+      operationId: "remove"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "Entity id to delete"
+        required: true
+        type: "integer"
+        maximum: 2147483647
+        minimum: 0
+        format: "int64"
+      responses:
+        400:
+          description: "Invalid entity value"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+  /pet/{petId}:
     post:
       tags:
       - "pet"
@@ -876,35 +927,6 @@ paths:
             $ref: "#/definitions/ApiResponse"
         405:
           description: "Invalid input"
-      security:
-      - petstore_auth:
-        - "write:pets"
-        - "read:pets"
-    delete:
-      tags:
-      - "pet"
-      summary: "Deletes a pet"
-      description: ""
-      operationId: "removePet"
-      produces:
-      - "application/xml"
-      - "application/json"
-      parameters:
-      - name: "api_key"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "petId"
-        in: "path"
-        description: "Pet id to delete"
-        required: true
-        type: "integer"
-        maximum: 2147483647
-        minimum: 0
-        format: "int64"
-      responses:
-        400:
-          description: "Invalid pet value"
       security:
       - petstore_auth:
         - "write:pets"

--- a/src/test/resources/sample-springmvc.html
+++ b/src/test/resources/sample-springmvc.html
@@ -1430,7 +1430,7 @@ This is a contrived example
 
 ### PUT
 
-<a id="updatePet">Update an existing pet</a>
+<a id="update">Update an existing entity</a>
 
 
 
@@ -1472,7 +1472,7 @@ This is a contrived example
     <th>body</th>
     <td>body</td>
     <td>yes</td>
-    <td>Pet object that needs to be added to the store</td>
+    <td>Entity that needs to be updated</td>
     <td> - </td>
 
     <td>
@@ -1496,7 +1496,7 @@ This is a contrived example
 |-------------|-------------|----------------|
 | 200    | successful operation | <a href="#/definitions/Pet">Pet</a>|
 | 400    | Invalid ID supplied |  - |
-| 404    | Pet not found |  - |
+| 404    | Entity not found |  - |
 | 405    | Validation exception |  - |
 
 
@@ -1506,7 +1506,7 @@ This is a contrived example
 ### POST
 
 
-<a id="addPet">Add a new pet to the store</a>
+<a id="save">Add a new entity to the store</a>
 
 
 
@@ -1548,7 +1548,7 @@ This is a contrived example
     <th>body</th>
     <td>body</td>
     <td>yes</td>
-    <td>Pet object that needs to be added to the store</td>
+    <td>Entity object that needs to be added to the store</td>
     <td> - </td>
 
     <td>
@@ -1572,6 +1572,69 @@ This is a contrived example
 |-------------|-------------|----------------|
 | 200    | successful operation | <a href="#/definitions/Pet">Pet</a>|
 | 405    | Invalid input |  - |
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+## /pet/
+
+
+### GET
+
+<a id="getAll">Returns all entities</a>
+
+
+
+
+
+
+#### Security
+
+
+
+
+* petstore_auth
+   * write:pets
+   * read:pets
+
+
+
+
+#### Request
+
+
+
+##### Parameters
+
+
+
+
+
+
+#### Response
+
+**Content-Type: ** application/json, application/xml
+
+
+| Status Code | Reason      | Response Model |
+|-------------|-------------|----------------|
+| 200    | Entity data found | Array[<a href="#/definitions/Pet">Pet</a>]|
+| 400    | Invalid ID supplied |  - |
+| 404    | Entity not found |  - |
+
+
+
 
 
 
@@ -2617,24 +2680,19 @@ If you wish to paginate the results of this API, supply offset and limit query p
 
 
 
-## /pet/{petId}
+## /pet/{id}
 
 
 ### GET
 
-<a id="getPetById">Find pet by ID</a>
+<a id="get">Find entity by ID</a>
 
-Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API error conditions
+Returns an entity when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API error conditions
 
 
 
 
 #### Security
-
-
-
-
-* api_key
 
 
 
@@ -2665,10 +2723,10 @@ Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API erro
 
 
 <tr>
-    <th>petId</th>
+    <th>id</th>
     <td>path</td>
     <td>yes</td>
-    <td>ID of pet that needs to be fetched</td>
+    <td>ID of the entity that needs to be fetched</td>
     <td> - </td>
 
     
@@ -2689,10 +2747,96 @@ Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API erro
 
 | Status Code | Reason      | Response Model |
 |-------------|-------------|----------------|
-| 200    | Pet data found | <a href="#/definitions/Pet">Pet</a>|
+| 200    | Entity data found | <a href="#/definitions/Pet">Pet</a>|
 | 400    | Invalid ID supplied |  - |
-| 404    | Pet not found |  - |
+| 404    | Entity not found |  - |
 
+
+
+
+
+
+
+
+
+### DELETE
+
+<a id="remove">Deletes an entity</a>
+
+
+
+
+
+
+#### Security
+
+
+
+
+* petstore_auth
+   * write:pets
+   * read:pets
+
+
+
+
+#### Request
+
+
+
+##### Parameters
+
+<table border="1">
+    <tr>
+        <th>Name</th>
+        <th>Located in</th>
+        <th>Required</th>
+        <th>Description</th>
+        <th>Default</th>
+        <th>Schema</th>
+    </tr>
+
+
+
+<tr>
+    <th>id</th>
+    <td>path</td>
+    <td>yes</td>
+    <td>Entity id to delete</td>
+    <td> - </td>
+
+    
+            <td>integer (int64)</td>
+    
+
+</tr>
+
+
+</table>
+
+
+
+#### Response
+
+**Content-Type: ** application/json, application/xml
+
+
+| Status Code | Reason      | Response Model |
+|-------------|-------------|----------------|
+| 400    | Invalid entity value |  - |
+
+
+
+
+
+
+
+
+
+
+
+
+## /pet/{petId}
 
 
 
@@ -2796,87 +2940,6 @@ Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API erro
 
 
 
-
-
-
-### DELETE
-
-<a id="removePet">Deletes a pet</a>
-
-
-
-
-
-
-#### Security
-
-
-
-
-* petstore_auth
-   * write:pets
-   * read:pets
-
-
-
-
-#### Request
-
-
-
-##### Parameters
-
-<table border="1">
-    <tr>
-        <th>Name</th>
-        <th>Located in</th>
-        <th>Required</th>
-        <th>Description</th>
-        <th>Default</th>
-        <th>Schema</th>
-    </tr>
-
-
-
-<tr>
-    <th>api_key</th>
-    <td>header</td>
-    <td>yes</td>
-    <td></td>
-    <td> - </td>
-
-    
-            <td>string </td>
-    
-
-</tr>
-
-<tr>
-    <th>petId</th>
-    <td>path</td>
-    <td>yes</td>
-    <td>Pet id to delete</td>
-    <td> - </td>
-
-    
-            <td>integer (int64)</td>
-    
-
-</tr>
-
-
-</table>
-
-
-
-#### Response
-
-**Content-Type: ** application/json, application/xml
-
-
-| Status Code | Reason      | Response Model |
-|-------------|-------------|----------------|
-| 400    | Invalid pet value |  - |
 
 
 


### PR DESCRIPTION
Over time I've found generic operations to be pretty useful in order to minimize controller code, especially on CRUD operations that tend to be repeated for different entities.

With this aproach you may define a generic CRUD controller implementing the most basic operations like get one, get all, update, insert and delete, and then just extend it in order to provide full functionality for each entity.

However, swagger spec generation just throws a NullPointerException whenever it encounters generic types since it doesn't seem to be able to solve the actual type. I came up with this solution in order to evaluate generic types and get a concrete type (not Object) in the resulting specification.

I've implemented this approach in the PetResource test controller and slighlty modified the expected outputs in order to test it.

P.S: Keep up the good work!