### PR TITLE
Beanparam fixes

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/jaxrs/BeanParamInjectParamExtention.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/jaxrs/BeanParamInjectParamExtention.java
@@ -1,51 +1,54 @@
 package com.github.kongchen.swagger.docgen.jaxrs;
 
+import com.github.kongchen.swagger.docgen.reader.JaxrsReader;
 import com.sun.jersey.api.core.InjectParam;
 import com.sun.jersey.core.header.FormDataContentDisposition;
-import io.swagger.annotations.ApiParam;
 import io.swagger.jaxrs.ext.AbstractSwaggerExtension;
 import io.swagger.jaxrs.ext.SwaggerExtension;
-import io.swagger.models.parameters.AbstractSerializableParameter;
 import io.swagger.models.parameters.Parameter;
-import io.swagger.models.parameters.SerializableParameter;
-import io.swagger.models.properties.PropertyBuilder;
-import io.swagger.util.AllowableValues;
-import io.swagger.util.AllowableValuesUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.TypeUtils;
 
 import javax.ws.rs.BeanParam;
 import java.lang.annotation.Annotation;
-import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
+ * This extension extracts the parameters inside a {@code @BeanParam} by
+ * exploding the target bean type's fields/methods and recursively feeding them
+ * back through the {@link JaxrsReader}.
+ * 
  * @author chekong on 15/5/9.
  */
 public class BeanParamInjectParamExtention extends AbstractSwaggerExtension {
 
+    private final JaxrsReader reader;
+    
+    public BeanParamInjectParamExtention(JaxrsReader reader) {
+        this.reader = reader;
+    }
+    
     @Override
     public List<Parameter> extractParameters(List<Annotation> annotations, Type type, Set<Type> typesToSkip, Iterator<SwaggerExtension> chain) {
         Class<?> cls = TypeUtils.getRawType(type, type);
 
-        List<Parameter> output = new ArrayList<Parameter>();
         if (shouldIgnoreClass(cls) || typesToSkip.contains(type)) {
             // stop the processing chain
             typesToSkip.add(type);
-            return output;
+            return Collections.emptyList();
         }
         for (Annotation annotation : annotations) {
             if (annotation instanceof BeanParam || annotation instanceof InjectParam) {
-                return extractParameters(cls);
+                return extractParameters(cls, typesToSkip);
             }
         }
         if (chain.hasNext()) {
@@ -54,59 +57,50 @@ public class BeanParamInjectParamExtention extends AbstractSwaggerExtension {
         return Collections.emptyList();
     }
 
-    private List<Parameter> extractParameters(Class<?> cls) {
-        List<Parameter> parameters = new ArrayList<Parameter>();
+    private List<Parameter> extractParameters(Class<?> cls, Set<Type> typesToSkip) {
+        
+        Collection<TypeWithAnnotations> typesWithAnnotations = new ArrayList<TypeWithAnnotations>();
+        
+        for (Field field : getDeclaredAndInheritedFields(cls)) {
+            Type type = field.getGenericType();
+            List<Annotation> annotations = Arrays.asList(field.getAnnotations());
+            typesWithAnnotations.add(new TypeWithAnnotations(type, annotations));
+        }
+        
+        /*
+         * For methods we will only examine setters and will only look at the
+         * annotations on the parameter, not the method itself.
+         */
+        for (Method method : getDeclaredAndInheritedMethods(cls)) {
 
-        for (AccessibleObject accessibleObject : getDeclaredAndInheritedFieldsAndMethods(cls)) {
-            SerializableParameter parameter = null;
-
-            int i = 0;
-            int apiParaIdx = -1;
-            boolean hidden = false;
-
-            for (Annotation annotation : accessibleObject.getAnnotations()) {
-                if (annotation instanceof ApiParam) {
-                    if (((ApiParam) annotation).hidden()) {
-                        hidden = true;
-                    } else {
-                        apiParaIdx = i;
-                    }
-                }
-                i++;
-                Type paramType = extractType(accessibleObject, cls);
-                parameter = JaxrsParameterExtension.getParameter(paramType, parameter, annotation);
+            Type[] parameterTypes = method.getGenericParameterTypes();
+            // skip methods that don't look like setters
+            if (parameterTypes.length != 1 || method.getReturnType() != void.class) {
+                continue;
             }
+            Type type = parameterTypes[0];
+            List<Annotation> annotations = Arrays.asList(JaxrsReader.findParamAnnotations(method)[0]);
+            typesWithAnnotations.add(new TypeWithAnnotations(type, annotations));
+        }
+        
+        List<Parameter> output = new ArrayList<Parameter>();
+        
+        for (TypeWithAnnotations typeWithAnnotations : typesWithAnnotations) {
+            
+            Type type = typeWithAnnotations.getType();
+            List<Annotation> annotations = typeWithAnnotations.getAnnotations();
 
-            if (parameter != null) {
-                if (apiParaIdx != -1) {
-                    ApiParam param = (ApiParam) accessibleObject.getAnnotations()[apiParaIdx];
-                    parameter.setDescription(param.value());
-                    parameter.setRequired(param.required());
-                    parameter.setAccess(param.access());
-
-                    if (parameter instanceof AbstractSerializableParameter && StringUtils.isNotEmpty(param.defaultValue())) {
-                        ((AbstractSerializableParameter)parameter).setDefaultValue(param.defaultValue());
-                    }
-
-                    AllowableValues allowableValues = AllowableValuesUtils.create(param.allowableValues());
-                    if (allowableValues != null) {
-                        Map<PropertyBuilder.PropertyId, Object> args = allowableValues.asPropertyArguments();
-                        if (args.containsKey(PropertyBuilder.PropertyId.ENUM)) {
-                            parameter.setEnum((List<String>) args.get(PropertyBuilder.PropertyId.ENUM));
-                        }
-                    }
-
-                    if (!param.name().isEmpty()) {
-                        parameter.setName(param.name());
-                    }
-                }
-                if (!hidden) {
-                    parameters.add(parameter);
-                }
-            }
+            /*
+             * Skip the type of the bean itself when recursing into its members in
+             * order to avoid cycles, as crazy as that user code would have to be.
+             */
+            Set<Type> recurseTypesToSkip = new HashSet<Type>(typesToSkip);
+            recurseTypesToSkip.add(cls);
+            
+            output.addAll(reader.getParameters(type, annotations, recurseTypesToSkip));
         }
 
-        return parameters;
+        return output;
     }
 
     @Override
@@ -114,38 +108,42 @@ public class BeanParamInjectParamExtention extends AbstractSwaggerExtension {
         return FormDataContentDisposition.class.equals(cls);
     }
 
-    private List<AccessibleObject> getDeclaredAndInheritedFieldsAndMethods(Class<?> clazz) {
-        List<AccessibleObject> accessibleObjects = new ArrayList<AccessibleObject>();
-        recurseGetDeclaredAndInheritedFields(clazz, accessibleObjects);
-        recurseGetDeclaredAndInheritedMethods(clazz, accessibleObjects);
-        return accessibleObjects;
+    private List<Field> getDeclaredAndInheritedFields(Class<?> clazz) {
+        List<Field> fields = new ArrayList<Field>();
+        Class<?> inspectedClass = clazz;
+        while (inspectedClass != null) {
+            fields.addAll(Arrays.asList(inspectedClass.getDeclaredFields()));
+            inspectedClass = inspectedClass.getSuperclass();
+        }
+        return fields;
     }
 
-    private void recurseGetDeclaredAndInheritedFields(Class<?> clazz, List<AccessibleObject> fields) {
-        fields.addAll(Arrays.asList(clazz.getDeclaredFields()));
-        Class<?> superClass = clazz.getSuperclass();
-        if (superClass != null) {
-            recurseGetDeclaredAndInheritedFields(superClass, fields);
+    private List<Method> getDeclaredAndInheritedMethods(Class<?> clazz) {
+        List<Method> methods = new ArrayList<Method>();
+        Class<?> inspectedClass = clazz;
+        while (inspectedClass != null) {
+            methods.addAll(Arrays.asList(inspectedClass.getDeclaredMethods()));
+            inspectedClass = inspectedClass.getSuperclass();
         }
+        return methods;
     }
 
-    private void recurseGetDeclaredAndInheritedMethods(Class<?> clazz, List<AccessibleObject> methods) {
-        methods.addAll(Arrays.asList(clazz.getDeclaredMethods()));
-        Class<?> superClass = clazz.getSuperclass();
-        if (superClass != null) {
-            recurseGetDeclaredAndInheritedMethods(superClass, methods);
-        }
-    }
+    private static final class TypeWithAnnotations {
 
-    private Type extractType(AccessibleObject accessibleObject, Type defaulType) {
-        if (accessibleObject instanceof Field) {
-            return ((Field) accessibleObject).getGenericType();
-        } else if (accessibleObject instanceof Method) {
-            Method method = (Method) accessibleObject;
-            if (method.getParameterTypes().length == 1) {
-                return method.getParameterTypes()[0];
-            }
+        final Type type;
+        final List<Annotation> annotations;
+        
+        TypeWithAnnotations(Type type, List<Annotation> annotations) {
+            this.type = type;
+            this.annotations = annotations;
         }
-        return defaulType;
+        
+        Type getType() {
+            return type;
+        }
+        
+        List<Annotation> getAnnotations() {
+            return annotations;
+        }
     }
 }

--- a/src/main/java/com/github/kongchen/swagger/docgen/jaxrs/BeanParamInjectParamExtention.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/jaxrs/BeanParamInjectParamExtention.java
@@ -153,19 +153,19 @@ public class BeanParamInjectParamExtention extends AbstractSwaggerExtension {
 
     private static final class TypeWithAnnotations {
 
-        final Type type;
-        final List<Annotation> annotations;
+        private final Type type;
+        private final List<Annotation> annotations;
         
         TypeWithAnnotations(Type type, List<Annotation> annotations) {
             this.type = type;
             this.annotations = annotations;
         }
         
-        Type getType() {
+        public Type getType() {
             return type;
         }
         
-        List<Annotation> getAnnotations() {
+        public List<Annotation> getAnnotations() {
             return annotations;
         }
     }

--- a/src/main/java/com/github/kongchen/swagger/docgen/jaxrs/BeanParamInjectParamExtention.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/jaxrs/BeanParamInjectParamExtention.java
@@ -10,6 +10,7 @@ import org.apache.commons.lang3.reflect.TypeUtils;
 
 import javax.ws.rs.BeanParam;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
@@ -83,6 +84,18 @@ public class BeanParamInjectParamExtention extends AbstractSwaggerExtension {
             typesWithAnnotations.add(new TypeWithAnnotations(type, annotations));
         }
         
+        for (Constructor<?> constructor : getDeclaredAndInheritedConstructors(cls)) {
+            
+            Type[] parameterTypes = constructor.getGenericParameterTypes();
+            Annotation[][] parameterAnnotations = constructor.getParameterAnnotations();
+            
+            for (int i = 0; i < parameterTypes.length; i++) {
+                Type type = parameterTypes[i];
+                List<Annotation> annotations = Arrays.asList(parameterAnnotations[i]);
+                typesWithAnnotations.add(new TypeWithAnnotations(type, annotations));
+            }
+        }
+        
         List<Parameter> output = new ArrayList<Parameter>();
         
         for (TypeWithAnnotations typeWithAnnotations : typesWithAnnotations) {
@@ -126,6 +139,16 @@ public class BeanParamInjectParamExtention extends AbstractSwaggerExtension {
             inspectedClass = inspectedClass.getSuperclass();
         }
         return methods;
+    }
+
+    private List<Constructor<?>> getDeclaredAndInheritedConstructors(Class<?> clazz) {
+        List<Constructor<?>> constructor = new ArrayList<Constructor<?>>();
+        Class<?> inspectedClass = clazz;
+        while (inspectedClass != null) {
+            constructor.addAll(Arrays.asList(inspectedClass.getDeclaredConstructors()));
+            inspectedClass = inspectedClass.getSuperclass();
+        }
+        return constructor;
     }
 
     private static final class TypeWithAnnotations {

--- a/src/main/java/com/github/kongchen/swagger/docgen/jaxrs/BeanParamInjectParamExtention.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/jaxrs/BeanParamInjectParamExtention.java
@@ -26,8 +26,8 @@ import java.util.Set;
 
 /**
  * This extension extracts the parameters inside a {@code @BeanParam} by
- * exploding the target bean type's fields/methods and recursively feeding them
- * back through the {@link JaxrsReader}.
+ * expanding the target bean type's fields/methods/constructor parameters and
+ * recursively feeding them back through the {@link JaxrsReader}.
  * 
  * @author chekong on 15/5/9.
  */

--- a/src/main/java/com/github/kongchen/swagger/docgen/jaxrs/BeanParamInjectParamExtention.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/jaxrs/BeanParamInjectParamExtention.java
@@ -104,8 +104,13 @@ public class BeanParamInjectParamExtention extends AbstractSwaggerExtension {
             List<Annotation> annotations = typeWithAnnotations.getAnnotations();
 
             /*
-             * Skip the type of the bean itself when recursing into its members in
-             * order to avoid cycles, as crazy as that user code would have to be.
+             * Skip the type of the bean itself when recursing into its members
+             * in order to avoid a cycle (stack overflow), as crazy as that user
+             * code would have to be.
+             * 
+             * There are no tests to prove this works because the test bean
+             * classes are shared with SwaggerReaderTest and Swagger's own logic
+             * doesn't prevent this problem.
              */
             Set<Type> recurseTypesToSkip = new HashSet<Type>(typesToSkip);
             recurseTypesToSkip.add(cls);

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
@@ -382,8 +382,14 @@ public abstract class AbstractReader {
 
         return hasValidAnnotation;
     }
+    
+    // this is final to enforce that only the implementation method below can be overridden, to avoid confusion
+    protected final List<Parameter> getParameters(Type type, List<Annotation> annotations) {
+        return getParameters(type, annotations, typesToSkip);
+    }
 
-    protected List<Parameter> getParameters(Type type, List<Annotation> annotations) {
+    // this method exists so that outside callers can choose their own custom types to skip
+    protected List<Parameter> getParameters(Type type, List<Annotation> annotations, Set<Type> typesToSkip) {
         if (!hasValidAnnotations(annotations) || isApiParamHidden(annotations)) {
             return Collections.emptyList();
         }

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
@@ -446,7 +446,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
 	}
 
 
-    public static Annotation[][] merge(Annotation[][] overriddenMethodParamAnnotation,
+    private static Annotation[][] merge(Annotation[][] overriddenMethodParamAnnotation,
 			Annotation[][] currentParamAnnotations) {
     	Annotation[][] mergedAnnotations = new Annotation[overriddenMethodParamAnnotation.length][];
 
@@ -456,7 +456,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
 		return mergedAnnotations;
 	}
 
-	public static Annotation[] merge(Annotation[] annotations,
+	private static Annotation[] merge(Annotation[] annotations,
 			Annotation[] annotations2) {
 		List<Annotation> mergedAnnotations = new ArrayList<Annotation>();
 		mergedAnnotations.addAll(Arrays.asList(annotations));

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
@@ -60,10 +60,19 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
         super(swagger, LOG);
     }
 
+    /**
+     * This is overridden and made public so that it can be called by
+     * {@link BeanParamInjectParamExtention}.
+     */
+    @Override
+    public List<Parameter> getParameters(Type type, List<Annotation> annotations, Set<Type> typesToSkip) {
+        return super.getParameters(type, annotations, typesToSkip);
+    }
+  
     @Override
     protected void updateExtensionChain() {
     	List<SwaggerExtension> extensions = new ArrayList<SwaggerExtension>();
-    	extensions.add(new BeanParamInjectParamExtention());
+    	extensions.add(new BeanParamInjectParamExtention(this));
         extensions.add(new SwaggerJerseyJaxrs());
         extensions.add(new JaxrsParameterExtension());
     	SwaggerExtensions.setExtensions(extensions);
@@ -425,7 +434,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
         return operation;
     }
 
-	private Annotation[][] findParamAnnotations(Method method) {
+	public static Annotation[][] findParamAnnotations(Method method) {
 		Annotation[][] paramAnnotation = method.getParameterAnnotations();
 
 		Method overriddenMethod = ReflectionUtils.getOverriddenMethod(method);
@@ -437,7 +446,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
 	}
 
 
-    private Annotation[][] merge(Annotation[][] overriddenMethodParamAnnotation,
+    public static Annotation[][] merge(Annotation[][] overriddenMethodParamAnnotation,
 			Annotation[][] currentParamAnnotations) {
     	Annotation[][] mergedAnnotations = new Annotation[overriddenMethodParamAnnotation.length][];
 
@@ -447,7 +456,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
 		return mergedAnnotations;
 	}
 
-	private Annotation[] merge(Annotation[] annotations,
+	public static Annotation[] merge(Annotation[] annotations,
 			Annotation[] annotations2) {
 		List<Annotation> mergedAnnotations = new ArrayList<Annotation>();
 		mergedAnnotations.addAll(Arrays.asList(annotations));

--- a/src/test/java/com/wordnik/jaxrs/MyBean.java
+++ b/src/test/java/com/wordnik/jaxrs/MyBean.java
@@ -113,4 +113,27 @@ public class MyBean extends MyParentBean {
         this.listValue = listValue;
     }
 
+    public MyNestedBean getNestedBean() {
+        return nestedBean;
+    }
+    
+    public void setNestedBean(MyNestedBean nestedBean) {
+        this.nestedBean = nestedBean;
+    }
+    
+    public MyConstructorInjectedNestedBean getConstructorInjectedNestedBean() {
+        return constructorInjectedNestedBean;
+    }
+    
+    public void setConstructorInjectedNestedBean(MyConstructorInjectedNestedBean constructorInjectedNestedBean) {
+        this.constructorInjectedNestedBean = constructorInjectedNestedBean;
+    }
+    
+    public int getConstrainedField() {
+        return constrainedField;
+    }
+    
+    public void setConstrainedField(int constrainedField) {
+        this.constrainedField = constrainedField;
+    }
 }

--- a/src/test/java/com/wordnik/jaxrs/MyBean.java
+++ b/src/test/java/com/wordnik/jaxrs/MyBean.java
@@ -39,7 +39,6 @@ public class MyBean extends MyParentBean {
     @QueryParam(value = "listValue")
     private List<String> listValue;
     
-    @ApiParam
     @BeanParam
     private MyNestedBean nestedBean;
 

--- a/src/test/java/com/wordnik/jaxrs/MyBean.java
+++ b/src/test/java/com/wordnik/jaxrs/MyBean.java
@@ -41,6 +41,13 @@ public class MyBean extends MyParentBean {
     
     @BeanParam
     private MyNestedBean nestedBean;
+    
+    /**
+     * This field is to test that bean params using constructor injection behave
+     * correctly. It's also nested just to avoid adding too much test code.
+     */
+    @BeanParam
+    private MyConstructorInjectedNestedBean constructorInjectedNestedBean;
 
     @ApiParam(value = "testIntegerAllowableValues", defaultValue = "25", allowableValues = "25, 50, 100")
     @QueryParam("testIntegerAllowableValues")

--- a/src/test/java/com/wordnik/jaxrs/MyBean.java
+++ b/src/test/java/com/wordnik/jaxrs/MyBean.java
@@ -2,7 +2,6 @@ package com.wordnik.jaxrs;
 
 import io.swagger.annotations.ApiParam;
 
-import javax.validation.constraints.Min;
 import javax.ws.rs.*;
 import java.util.List;
 
@@ -35,6 +34,10 @@ public class MyBean extends MyParentBean {
 
     @QueryParam(value = "listValue")
     private List<String> listValue;
+    
+    @ApiParam
+    @BeanParam
+    private MyNestedBean nestedBean;
 
     @ApiParam(value = "testIntegerAllowableValues", defaultValue = "25", allowableValues = "25, 50, 100")
     @QueryParam("testIntegerAllowableValues")

--- a/src/test/java/com/wordnik/jaxrs/MyBean.java
+++ b/src/test/java/com/wordnik/jaxrs/MyBean.java
@@ -2,6 +2,10 @@ package com.wordnik.jaxrs;
 
 import io.swagger.annotations.ApiParam;
 
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.ws.rs.*;
 import java.util.List;
 
@@ -41,8 +45,19 @@ public class MyBean extends MyParentBean {
 
     @ApiParam(value = "testIntegerAllowableValues", defaultValue = "25", allowableValues = "25, 50, 100")
     @QueryParam("testIntegerAllowableValues")
-    @DefaultValue("25")
     public Integer testIntegerAllowableValues;
+    
+    /**
+     * This field's allowableValues, required, pattern, and defaultValue should
+     * be derived based on its JAX-RS and validation annotations.
+     */
+    @QueryParam("constrainedField")
+    @Min(25L)
+    @Max(75L)
+    @NotNull
+    @Pattern(regexp = "[0-9]5")
+    @DefaultValue("55")
+    private int constrainedField;
 
     public String getMyheader() {
         return myHeader;

--- a/src/test/java/com/wordnik/jaxrs/MyConstructorInjectedNestedBean.java
+++ b/src/test/java/com/wordnik/jaxrs/MyConstructorInjectedNestedBean.java
@@ -19,7 +19,7 @@ public class MyConstructorInjectedNestedBean {
      */
     private final String constructorInjectedHeader;
     
-    // @Inject would typically go here, telling e.g. Jersey to use constructor injection
+    // @Inject would typically go here in real life, telling e.g. Jersey to use constructor injection
     public MyConstructorInjectedNestedBean(
             @ApiParam("Header injected at constructor")
             @HeaderParam("constructorInjectedHeader")

--- a/src/test/java/com/wordnik/jaxrs/MyConstructorInjectedNestedBean.java
+++ b/src/test/java/com/wordnik/jaxrs/MyConstructorInjectedNestedBean.java
@@ -1,6 +1,5 @@
 package com.wordnik.jaxrs;
 
-import javax.ws.rs.BeanParam;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.HeaderParam;
 
@@ -13,32 +12,23 @@ import io.swagger.annotations.ApiParam;
  */
 public class MyConstructorInjectedNestedBean {
     
+    /**
+     * Note: this property will not be found by
+     * {@link com.github.kongchen.swagger.docgen.reader.SwaggerReader}, which
+     * seems to be a limitation of {@link io.swagger.jaxrs.Reader} itself.
+     */
     private final String constructorInjectedHeader;
     
-    /**
-     * This bean param should be ignored because otherwise we would cycle
-     * endlessly until stack overflow.
-     */
-    private final MyBean evilNestedBeanParamCycle;
-    
     public MyConstructorInjectedNestedBean(
-            
             @ApiParam("Header injected at constructor")
             @HeaderParam("constructorInjectedHeader")
             @DefaultValue("foo")
-            String constructorInjectedHeader,
-            
-            @BeanParam MyBean evilNestedBeanParamCycle
+            String constructorInjectedHeader
     ) {
         this.constructorInjectedHeader = constructorInjectedHeader;
-        this.evilNestedBeanParamCycle = evilNestedBeanParamCycle;
     }
 
-    public String getMyNestedBeanHeader() {
+    public String getConstructorInjectedHeader() {
         return constructorInjectedHeader;
-    }
-    
-    public MyBean getEvilNestedBeanParamCycle() {
-        return evilNestedBeanParamCycle;
     }
 }

--- a/src/test/java/com/wordnik/jaxrs/MyConstructorInjectedNestedBean.java
+++ b/src/test/java/com/wordnik/jaxrs/MyConstructorInjectedNestedBean.java
@@ -19,6 +19,7 @@ public class MyConstructorInjectedNestedBean {
      */
     private final String constructorInjectedHeader;
     
+    // @Inject would typically go here, telling e.g. Jersey to use constructor injection
     public MyConstructorInjectedNestedBean(
             @ApiParam("Header injected at constructor")
             @HeaderParam("constructorInjectedHeader")

--- a/src/test/java/com/wordnik/jaxrs/MyConstructorInjectedNestedBean.java
+++ b/src/test/java/com/wordnik/jaxrs/MyConstructorInjectedNestedBean.java
@@ -1,0 +1,44 @@
+package com.wordnik.jaxrs;
+
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.HeaderParam;
+
+import io.swagger.annotations.ApiParam;
+
+/**
+ * Represents a nested {@code @BeanParam} target that is injected by constructor.
+ * 
+ * @see MyNestedBean
+ */
+public class MyConstructorInjectedNestedBean {
+    
+    private final String constructorInjectedHeader;
+    
+    /**
+     * This bean param should be ignored because otherwise we would cycle
+     * endlessly until stack overflow.
+     */
+    private final MyBean evilNestedBeanParamCycle;
+    
+    public MyConstructorInjectedNestedBean(
+            
+            @ApiParam("Header injected at constructor")
+            @HeaderParam("constructorInjectedHeader")
+            @DefaultValue("foo")
+            String constructorInjectedHeader,
+            
+            @BeanParam MyBean evilNestedBeanParamCycle
+    ) {
+        this.constructorInjectedHeader = constructorInjectedHeader;
+        this.evilNestedBeanParamCycle = evilNestedBeanParamCycle;
+    }
+
+    public String getMyNestedBeanHeader() {
+        return constructorInjectedHeader;
+    }
+    
+    public MyBean getEvilNestedBeanParamCycle() {
+        return evilNestedBeanParamCycle;
+    }
+}

--- a/src/test/java/com/wordnik/jaxrs/MyNestedBean.java
+++ b/src/test/java/com/wordnik/jaxrs/MyNestedBean.java
@@ -1,5 +1,6 @@
 package com.wordnik.jaxrs;
 
+import javax.ws.rs.BeanParam;
 import javax.ws.rs.HeaderParam;
 
 import io.swagger.annotations.ApiParam;
@@ -12,6 +13,13 @@ public class MyNestedBean {
     @ApiParam(value = "Header from nested bean", required = false)
     @HeaderParam("myNestedBeanHeader")
     private String myNestedBeanHeader;
+    
+    /**
+     * This bean param should be ignored because otherwise we would cycle
+     * endlessly until stack overflow.
+     */
+    @BeanParam
+    private MyBean evilNestedBeanParamCycle;
 
     public String getMyNestedBeanHeader() {
         return myNestedBeanHeader;

--- a/src/test/java/com/wordnik/jaxrs/MyNestedBean.java
+++ b/src/test/java/com/wordnik/jaxrs/MyNestedBean.java
@@ -1,6 +1,5 @@
 package com.wordnik.jaxrs;
 
-import javax.ws.rs.BeanParam;
 import javax.ws.rs.HeaderParam;
 
 import io.swagger.annotations.ApiParam;
@@ -13,13 +12,6 @@ public class MyNestedBean {
     @ApiParam("Header from nested bean")
     @HeaderParam("myNestedBeanHeader")
     private String myNestedBeanHeader;
-    
-    /**
-     * This bean param should be ignored because otherwise we would cycle
-     * endlessly until stack overflow.
-     */
-    @BeanParam
-    private MyBean evilNestedBeanParamCycle;
 
     public String getMyNestedBeanHeader() {
         return myNestedBeanHeader;
@@ -27,13 +19,5 @@ public class MyNestedBean {
     
     public void setMyNestedBeanHeader(String myNestedBeanHeader) {
         this.myNestedBeanHeader = myNestedBeanHeader;
-    }
-    
-    public MyBean getEvilNestedBeanParamCycle() {
-        return evilNestedBeanParamCycle;
-    }
-    
-    public void setEvilNestedBeanParamCycle(MyBean evilNestedBeanParamCycle) {
-        this.evilNestedBeanParamCycle = evilNestedBeanParamCycle;
     }
 }

--- a/src/test/java/com/wordnik/jaxrs/MyNestedBean.java
+++ b/src/test/java/com/wordnik/jaxrs/MyNestedBean.java
@@ -1,0 +1,23 @@
+package com.wordnik.jaxrs;
+
+import javax.ws.rs.HeaderParam;
+
+import io.swagger.annotations.ApiParam;
+
+/**
+ * Represents a {@code @BeanParam} target that is nested within another bean.
+ */
+public class MyNestedBean {
+    
+    @ApiParam(value = "Header from nested bean", required = false)
+    @HeaderParam("myNestedBeanHeader")
+    private String myNestedBeanHeader;
+
+    public String getMyNestedBeanHeader() {
+        return myNestedBeanHeader;
+    }
+    
+    public void setMyNestedBeanHeader(String myNestedBeanHeader) {
+        this.myNestedBeanHeader = myNestedBeanHeader;
+    }
+}

--- a/src/test/java/com/wordnik/jaxrs/MyNestedBean.java
+++ b/src/test/java/com/wordnik/jaxrs/MyNestedBean.java
@@ -10,7 +10,7 @@ import io.swagger.annotations.ApiParam;
  */
 public class MyNestedBean {
     
-    @ApiParam(value = "Header from nested bean", required = false)
+    @ApiParam("Header from nested bean")
     @HeaderParam("myNestedBeanHeader")
     private String myNestedBeanHeader;
     
@@ -27,5 +27,13 @@ public class MyNestedBean {
     
     public void setMyNestedBeanHeader(String myNestedBeanHeader) {
         this.myNestedBeanHeader = myNestedBeanHeader;
+    }
+    
+    public MyBean getEvilNestedBeanParamCycle() {
+        return evilNestedBeanParamCycle;
+    }
+    
+    public void setEvilNestedBeanParamCycle(MyBean evilNestedBeanParamCycle) {
+        this.evilNestedBeanParamCycle = evilNestedBeanParamCycle;
     }
 }

--- a/src/test/resources/expectedOutput/swagger-swaggerreader.json
+++ b/src/test/resources/expectedOutput/swagger-swaggerreader.json
@@ -651,16 +651,6 @@
           "default" : 25,
           "format" : "int32",
           "enum" : [ 25, 50, 100 ]
-        }, {
-            "name": "constrainedField",
-            "in": "query",
-            "required": true,
-            "type": "integer",
-            "minimum": 25,
-            "maximum": 75,
-            "default": 55,
-            "pattern": "[0-9]5",
-            "format": "int32"
         } ],
         "responses" : {
           "405" : {
@@ -1207,9 +1197,6 @@
     },
     "MyBean" : {
       "type" : "object",
-      "required" : [
-        "constrainedField"
-      ],
       "properties" : {
         "myParentheader" : {
           "type" : "string"
@@ -1235,12 +1222,6 @@
         },
         "testIntegerAllowableValues" : {
           "type" : "integer",
-          "format" : "int32"
-        },
-        "constrainedField" : {
-          "type" : "integer",
-          "minimum" : 25,
-          "maximum" : 75,
           "format" : "int32"
         },
         "myheader" : {

--- a/src/test/resources/expectedOutput/swagger-swaggerreader.json
+++ b/src/test/resources/expectedOutput/swagger-swaggerreader.json
@@ -643,6 +643,12 @@
           },
           "collectionFormat" : "multi"
         }, {
+          "name" : "myNestedBeanHeader",
+          "in" : "header",
+          "description" : "Header from nested bean",
+          "required" : false,
+          "type" : "string"
+        }, {
           "name" : "testIntegerAllowableValues",
           "in" : "query",
           "description" : "testIntegerAllowableValues",
@@ -651,6 +657,16 @@
           "default" : 25,
           "format" : "int32",
           "enum" : [ 25, 50, 100 ]
+        }, {
+            "name": "constrainedField",
+            "in": "query",
+            "required": true,
+            "type": "integer",
+            "minimum": 25,
+            "maximum": 75,
+            "default": 55,
+            "pattern": "[0-9]5",
+            "format": "int32"
         } ],
         "responses" : {
           "405" : {
@@ -1197,6 +1213,9 @@
     },
     "MyBean" : {
       "type" : "object",
+      "required" : [
+        "constrainedField"
+      ],
       "properties" : {
         "myParentheader" : {
           "type" : "string"
@@ -1220,11 +1239,39 @@
             "type" : "string"
           }
         },
+        "nestedBean" : {
+          "$ref" : "#/definitions/MyNestedBean"
+        },
+        "constructorInjectedNestedBean" : {
+          "$ref" : "#/definitions/MyConstructorInjectedNestedBean"
+        },
         "testIntegerAllowableValues" : {
           "type" : "integer",
           "format" : "int32"
         },
+        "constrainedField" : {
+          "type" : "integer",
+          "minimum" : 25,
+          "maximum" : 75,
+          "format" : "int32"
+        },
         "myheader" : {
+          "type" : "string"
+        }
+      }
+    },
+    "MyNestedBean" : {
+      "type" : "object",
+      "properties" : {
+        "myNestedBeanHeader" : {
+          "type" : "string"
+        }
+      }
+    },
+    "MyConstructorInjectedNestedBean" : {
+      "type" : "object",
+      "properties" : {
+        "constructorInjectedHeader" : {
           "type" : "string"
         }
       }

--- a/src/test/resources/expectedOutput/swagger-swaggerreader.json
+++ b/src/test/resources/expectedOutput/swagger-swaggerreader.json
@@ -651,6 +651,16 @@
           "default" : 25,
           "format" : "int32",
           "enum" : [ 25, 50, 100 ]
+        }, {
+            "name": "constrainedField",
+            "in": "query",
+            "required": true,
+            "type": "integer",
+            "minimum": 25,
+            "maximum": 75,
+            "default": 55,
+            "pattern": "[0-9]5",
+            "format": "int32"
         } ],
         "responses" : {
           "405" : {
@@ -1197,6 +1207,9 @@
     },
     "MyBean" : {
       "type" : "object",
+      "required" : [
+        "constrainedField"
+      ],
       "properties" : {
         "myParentheader" : {
           "type" : "string"
@@ -1222,6 +1235,12 @@
         },
         "testIntegerAllowableValues" : {
           "type" : "integer",
+          "format" : "int32"
+        },
+        "constrainedField" : {
+          "type" : "integer",
+          "minimum" : 25,
+          "maximum" : 75,
           "format" : "int32"
         },
         "myheader" : {

--- a/src/test/resources/expectedOutput/swagger-swaggerreader.yaml
+++ b/src/test/resources/expectedOutput/swagger-swaggerreader.yaml
@@ -579,6 +579,15 @@ paths:
         - 25
         - 50
         - 100
+      - name: "constrainedField"
+        in: "query"
+        required: true
+        type: "integer"
+        minimum: 25
+        maximum: 75
+        default: 55
+        pattern: "[0-9]5"
+        format: "int32"
       responses:
         405:
           description: "Invalid input"
@@ -1052,6 +1061,8 @@ definitions:
       namespace: "http://com.wordnik/sample/model"
   MyBean:
     type: "object"
+    required:
+    - "constrainedField"
     properties:
       myParentheader:
         type: "string"
@@ -1071,6 +1082,11 @@ definitions:
       testIntegerAllowableValues:
         type: "integer"
         format: "int32"
+      constrainedField:
+        type: "integer"
+        format: "int32"
+        minimum: 25
+        maximum: 75
       myheader:
         type: "string"
   Order:

--- a/src/test/resources/expectedOutput/swagger-swaggerreader.yaml
+++ b/src/test/resources/expectedOutput/swagger-swaggerreader.yaml
@@ -579,15 +579,6 @@ paths:
         - 25
         - 50
         - 100
-      - name: "constrainedField"
-        in: "query"
-        required: true
-        type: "integer"
-        minimum: 25
-        maximum: 75
-        default: 55
-        pattern: "[0-9]5"
-        format: "int32"
       responses:
         405:
           description: "Invalid input"
@@ -1061,8 +1052,6 @@ definitions:
       namespace: "http://com.wordnik/sample/model"
   MyBean:
     type: "object"
-    required:
-    - "constrainedField"
     properties:
       myParentheader:
         type: "string"
@@ -1082,11 +1071,6 @@ definitions:
       testIntegerAllowableValues:
         type: "integer"
         format: "int32"
-      constrainedField:
-        type: "integer"
-        format: "int32"
-        minimum: 25
-        maximum: 75
       myheader:
         type: "string"
   Order:

--- a/src/test/resources/expectedOutput/swagger-swaggerreader.yaml
+++ b/src/test/resources/expectedOutput/swagger-swaggerreader.yaml
@@ -568,6 +568,11 @@ paths:
         items:
           type: "string"
         collectionFormat: "multi"
+      - name: "myNestedBeanHeader"
+        in: "header"
+        description: "Header from nested bean"
+        required: false
+        type: "string"
       - name: "testIntegerAllowableValues"
         in: "query"
         description: "testIntegerAllowableValues"
@@ -579,6 +584,15 @@ paths:
         - 25
         - 50
         - 100
+      - name: "constrainedField"
+        in: "query"
+        required: true
+        type: "integer"
+        minimum: 25
+        maximum: 75
+        default: 55
+        pattern: "[0-9]5"
+        format: "int32"
       responses:
         405:
           description: "Invalid input"
@@ -1052,6 +1066,8 @@ definitions:
       namespace: "http://com.wordnik/sample/model"
   MyBean:
     type: "object"
+    required:
+    - "constrainedField"
     properties:
       myParentheader:
         type: "string"
@@ -1068,10 +1084,29 @@ definitions:
         type: "array"
         items:
           type: "string"
+      nestedBean:
+        $ref: "#/definitions/MyNestedBean"
+      constructorInjectedNestedBean:
+        $ref: "#/definitions/MyConstructorInjectedNestedBean"
       testIntegerAllowableValues:
         type: "integer"
         format: "int32"
+      constrainedField:
+        type: "integer"
+        format: "int32"
+        minimum: 25
+        maximum: 75
       myheader:
+        type: "string"
+  MyNestedBean:
+    type: "object"
+    properties:
+      myNestedBeanHeader:
+        type: "string"
+  MyConstructorInjectedNestedBean:
+    type: "object"
+    properties:
+      constructorInjectedHeader:
         type: "string"
   Order:
     type: "object"

--- a/src/test/resources/expectedOutput/swagger-with-converter.json
+++ b/src/test/resources/expectedOutput/swagger-with-converter.json
@@ -901,6 +901,13 @@
             "collectionFormat": "multi"
           },
           {
+            "name": "myNestedBeanHeader",
+            "in": "header",
+            "description": "Header from nested bean",
+            "required": false,
+            "type": "string"
+          },
+          {
             "name": "testIntegerAllowableValues",
             "in": "query",
             "description": "testIntegerAllowableValues",
@@ -1037,6 +1044,13 @@
             "type": "array",
             "items": { "type": "string" },
             "collectionFormat": "multi"
+          },
+          {
+            "name": "myNestedBeanHeader",
+            "in": "header",
+            "description": "Header from nested bean",
+            "required": false,
+            "type": "string"
           },
           {
             "name": "testIntegerAllowableValues",

--- a/src/test/resources/expectedOutput/swagger-with-converter.json
+++ b/src/test/resources/expectedOutput/swagger-with-converter.json
@@ -922,6 +922,17 @@
             ]
           },
           {
+            "name": "constrainedField",
+            "in": "query",
+            "required": true,
+            "type": "integer",
+            "minimum": 25,
+            "maximum": 75,
+            "default": 55,
+            "pattern": "[0-9]5",
+            "format": "int32"
+          },
+          {
             "name": "myParentHeader",
             "in": "header",
             "description": "Header from parent",
@@ -1065,6 +1076,17 @@
               50,
               100
             ]
+          },
+          {
+            "name": "constrainedField",
+            "in": "query",
+            "required": true,
+            "type": "integer",
+            "minimum": 25,
+            "maximum": 75,
+            "default": 55,
+            "pattern": "[0-9]5",
+            "format": "int32"
           },
           {
             "name": "myParentHeader",

--- a/src/test/resources/expectedOutput/swagger-with-converter.json
+++ b/src/test/resources/expectedOutput/swagger-with-converter.json
@@ -908,6 +908,14 @@
             "type": "string"
           },
           {
+            "name": "constructorInjectedHeader",
+            "in": "header",
+            "description": "Header injected at constructor",
+            "required": false,
+            "type": "string",
+            "default": "foo"
+          },
+          {
             "name": "testIntegerAllowableValues",
             "in": "query",
             "description": "testIntegerAllowableValues",
@@ -1062,6 +1070,14 @@
             "description": "Header from nested bean",
             "required": false,
             "type": "string"
+          },
+          {
+            "name": "constructorInjectedHeader",
+            "in": "header",
+            "description": "Header injected at constructor",
+            "required": false,
+            "type": "string",
+            "default": "foo"
           },
           {
             "name": "testIntegerAllowableValues",

--- a/src/test/resources/expectedOutput/swagger-with-converter.yaml
+++ b/src/test/resources/expectedOutput/swagger-with-converter.yaml
@@ -637,6 +637,12 @@ paths:
         description: "Header from nested bean"
         required: false
         type: "string"
+      - name: "constructorInjectedHeader"
+        in: "header"
+        description: "Header injected at constructor"
+        required: false
+        type: "string"
+        default: "foo"
       - name: "testIntegerAllowableValues"
         in: "query"
         description: "testIntegerAllowableValues"
@@ -749,6 +755,12 @@ paths:
         description: "Header from nested bean"
         required: false
         type: "string"
+      - name: "constructorInjectedHeader"
+        in: "header"
+        description: "Header injected at constructor"
+        required: false
+        type: "string"
+        default: "foo"
       - name: "testIntegerAllowableValues"
         in: "query"
         description: "testIntegerAllowableValues"

--- a/src/test/resources/expectedOutput/swagger-with-converter.yaml
+++ b/src/test/resources/expectedOutput/swagger-with-converter.yaml
@@ -648,6 +648,15 @@ paths:
         - 25
         - 50
         - 100
+      - name: "constrainedField"
+        in: "query"
+        required: true
+        type: "integer"
+        minimum: 25
+        maximum: 75
+        default: 55
+        pattern: "[0-9]5"
+        format: "int32"
       - name: "myParentHeader"
         in: "header"
         description: "Header from parent"
@@ -751,6 +760,15 @@ paths:
         - 25
         - 50
         - 100
+      - name: "constrainedField"
+        in: "query"
+        required: true
+        type: "integer"
+        minimum: 25
+        maximum: 75
+        default: 55
+        pattern: "[0-9]5"
+        format: "int32"
       - name: "myParentHeader"
         in: "header"
         description: "Header from parent"

--- a/src/test/resources/expectedOutput/swagger-with-converter.yaml
+++ b/src/test/resources/expectedOutput/swagger-with-converter.yaml
@@ -632,6 +632,11 @@ paths:
         items:
           type: "string"
         collectionFormat: "multi"
+      - name: "myNestedBeanHeader"
+        in: "header"
+        description: "Header from nested bean"
+        required: false
+        type: "string"
       - name: "testIntegerAllowableValues"
         in: "query"
         description: "testIntegerAllowableValues"
@@ -730,6 +735,11 @@ paths:
         items:
           type: "string"
         collectionFormat: "multi"
+      - name: "myNestedBeanHeader"
+        in: "header"
+        description: "Header from nested bean"
+        required: false
+        type: "string"
       - name: "testIntegerAllowableValues"
         in: "query"
         description: "testIntegerAllowableValues"

--- a/src/test/resources/expectedOutput/swagger.json
+++ b/src/test/resources/expectedOutput/swagger.json
@@ -903,6 +903,13 @@
             "collectionFormat": "multi"
           },
           {
+            "name": "myNestedBeanHeader",
+            "in": "header",
+            "description": "Header from nested bean",
+            "required": false,
+            "type": "string"
+          },
+          {
             "name": "testIntegerAllowableValues",
             "in": "query",
             "description": "testIntegerAllowableValues",
@@ -1042,6 +1049,13 @@
             "type": "array",
             "items": { "type": "string" },
             "collectionFormat": "multi"
+          },
+          {
+            "name": "myNestedBeanHeader",
+            "in": "header",
+            "description": "Header from nested bean",
+            "required": false,
+            "type": "string"
           },
           {
             "name": "testIntegerAllowableValues",

--- a/src/test/resources/expectedOutput/swagger.json
+++ b/src/test/resources/expectedOutput/swagger.json
@@ -910,6 +910,14 @@
             "type": "string"
           },
           {
+            "name": "constructorInjectedHeader",
+            "in": "header",
+            "description": "Header injected at constructor",
+            "required": false,
+            "type": "string",
+            "default": "foo"
+          },
+          {
             "name": "testIntegerAllowableValues",
             "in": "query",
             "description": "testIntegerAllowableValues",
@@ -1067,6 +1075,14 @@
             "description": "Header from nested bean",
             "required": false,
             "type": "string"
+          },
+          {
+            "name": "constructorInjectedHeader",
+            "in": "header",
+            "description": "Header injected at constructor",
+            "required": false,
+            "type": "string",
+            "default": "foo"
           },
           {
             "name": "testIntegerAllowableValues",

--- a/src/test/resources/expectedOutput/swagger.json
+++ b/src/test/resources/expectedOutput/swagger.json
@@ -924,6 +924,17 @@
             ]
           },
           {
+            "name": "constrainedField",
+            "in": "query",
+            "required": true,
+            "type": "integer",
+            "minimum": 25,
+            "maximum": 75,
+            "default": 55,
+            "pattern": "[0-9]5",
+            "format": "int32"
+          },
+          {
             "name": "myParentHeader",
             "in": "header",
             "description": "Header from parent",
@@ -1070,6 +1081,17 @@
               50,
               100
             ]
+          },
+          {
+            "name": "constrainedField",
+            "in": "query",
+            "required": true,
+            "type": "integer",
+            "minimum": 25,
+            "maximum": 75,
+            "default": 55,
+            "pattern": "[0-9]5",
+            "format": "int32"
           },
           {
             "name": "myParentHeader",

--- a/src/test/resources/expectedOutput/swagger.yaml
+++ b/src/test/resources/expectedOutput/swagger.yaml
@@ -637,6 +637,12 @@ paths:
         description: "Header from nested bean"
         required: false
         type: "string"
+      - name: "constructorInjectedHeader"
+        in: "header"
+        description: "Header injected at constructor"
+        required: false
+        type: "string"
+        default: "foo"
       - name: "testIntegerAllowableValues"
         in: "query"
         description: "testIntegerAllowableValues"
@@ -749,6 +755,12 @@ paths:
         description: "Header from nested bean"
         required: false
         type: "string"
+      - name: "constructorInjectedHeader"
+        in: "header"
+        description: "Header injected at constructor"
+        required: false
+        type: "string"
+        default: "foo"
       - name: "testIntegerAllowableValues"
         in: "query"
         description: "testIntegerAllowableValues"

--- a/src/test/resources/expectedOutput/swagger.yaml
+++ b/src/test/resources/expectedOutput/swagger.yaml
@@ -648,6 +648,15 @@ paths:
         - 25
         - 50
         - 100
+      - name: "constrainedField"
+        in: "query"
+        required: true
+        type: "integer"
+        minimum: 25
+        maximum: 75
+        default: 55
+        pattern: "[0-9]5"
+        format: "int32"
       - name: "myParentHeader"
         in: "header"
         description: "Header from parent"
@@ -751,6 +760,15 @@ paths:
         - 25
         - 50
         - 100
+      - name: "constrainedField"
+        in: "query"
+        required: true
+        type: "integer"
+        minimum: 25
+        maximum: 75
+        default: 55
+        pattern: "[0-9]5"
+        format: "int32"
       - name: "myParentHeader"
         in: "header"
         description: "Header from parent"

--- a/src/test/resources/expectedOutput/swagger.yaml
+++ b/src/test/resources/expectedOutput/swagger.yaml
@@ -632,6 +632,11 @@ paths:
         items:
           type: "string"
         collectionFormat: "multi"
+      - name: "myNestedBeanHeader"
+        in: "header"
+        description: "Header from nested bean"
+        required: false
+        type: "string"
       - name: "testIntegerAllowableValues"
         in: "query"
         description: "testIntegerAllowableValues"
@@ -730,6 +735,11 @@ paths:
         items:
           type: "string"
         collectionFormat: "multi"
+      - name: "myNestedBeanHeader"
+        in: "header"
+        description: "Header from nested bean"
+        required: false
+        type: "string"
       - name: "testIntegerAllowableValues"
         in: "query"
         description: "testIntegerAllowableValues"

--- a/src/test/resources/sample.html
+++ b/src/test/resources/sample.html
@@ -1826,6 +1826,19 @@ Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API erro
 </tr>
 
 <tr>
+    <th>constrainedField</th>
+    <td>query</td>
+    <td>yes</td>
+    <td> (**Pattern**: `[0-9]5`)</td>
+    <td> - </td>
+
+
+            <td>integer (int32)</td>
+
+
+</tr>
+
+<tr>
     <th>myParentHeader</th>
     <td>header</td>
     <td>no</td>
@@ -2091,6 +2104,19 @@ Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API erro
     <td>query</td>
     <td>no</td>
     <td>testIntegerAllowableValues</td>
+    <td> - </td>
+
+
+            <td>integer (int32)</td>
+
+
+</tr>
+
+<tr>
+    <th>constrainedField</th>
+    <td>query</td>
+    <td>yes</td>
+    <td> (**Pattern**: `[0-9]5`)</td>
     <td> - </td>
 
 

--- a/src/test/resources/sample.html
+++ b/src/test/resources/sample.html
@@ -1813,6 +1813,19 @@ Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API erro
 </tr>
 
 <tr>
+    <th>constructorInjectedHeader</th>
+    <td>header</td>
+    <td>no</td>
+    <td>Header injected at constructor</td>
+    <td> - </td>
+
+
+            <td>string </td>
+
+
+</tr>
+
+<tr>
     <th>testIntegerAllowableValues</th>
     <td>query</td>
     <td>no</td>
@@ -2091,6 +2104,19 @@ Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API erro
     <td>header</td>
     <td>no</td>
     <td>Header from nested bean</td>
+    <td> - </td>
+
+
+            <td>string </td>
+
+
+</tr>
+
+<tr>
+    <th>constructorInjectedHeader</th>
+    <td>header</td>
+    <td>no</td>
+    <td>Header injected at constructor</td>
     <td> - </td>
 
 

--- a/src/test/resources/sample.html
+++ b/src/test/resources/sample.html
@@ -1800,6 +1800,19 @@ Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API erro
 </tr>
 
 <tr>
+    <th>myNestedBeanHeader</th>
+    <td>header</td>
+    <td>no</td>
+    <td>Header from nested bean</td>
+    <td> - </td>
+
+
+            <td>string </td>
+
+
+</tr>
+
+<tr>
     <th>testIntegerAllowableValues</th>
     <td>query</td>
     <td>no</td>
@@ -2056,6 +2069,19 @@ Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API erro
 
 
              <td>Array[string] (multi)</td>
+
+
+</tr>
+
+<tr>
+    <th>myNestedBeanHeader</th>
+    <td>header</td>
+    <td>no</td>
+    <td>Header from nested bean</td>
+    <td> - </td>
+
+
+            <td>string </td>
 
 
 </tr>


### PR DESCRIPTION
The existing support for `@BeanParam` has some issues:
- It doesn't recurse into nested `@BeanParam` fields.
- It doesn't properly detect `javax.validation.constraints.*` annotations or `@DefaultValue`.
- It doesn't detect swagger info on constructors used to inject into `@BeanParam` classes.

Basically the solution is to redesign `BeanParamInjectParamExtention` to just do the work of expanding `@BeanParam` into its underlying fields, and then piping those fields back through the `JaxrsReader` so that they're processed by the standard logic.