### PR TITLE
Chain next swagger extension

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/jaxrs/BeanParamInjectParamExtention.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/jaxrs/BeanParamInjectParamExtention.java
@@ -11,19 +11,8 @@ import org.apache.commons.lang3.reflect.TypeUtils;
 
 import javax.ws.rs.BeanParam;
 import java.lang.annotation.Annotation;
-import java.lang.reflect.AccessibleObject;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
+import java.lang.reflect.*;
+import java.util.*;
 
 /**
  * This extension extracts the parameters inside a {@code @BeanParam} by
@@ -75,10 +64,7 @@ public class BeanParamInjectParamExtention extends AbstractSwaggerExtension {
                 return extractParameters(cls, typesToSkip);
             }
         }
-        if (chain.hasNext()) {
-            return chain.next().extractParameters(annotations, type, typesToSkip, chain);
-        }
-        return Lists.newArrayList();
+        return super.extractParameters(annotations, type, typesToSkip, chain);
     }
 
     private List<Parameter> extractParameters(Class<?> cls, Set<Type> typesToSkip) {

--- a/src/main/java/com/github/kongchen/swagger/docgen/jaxrs/BeanParamInjectParamExtention.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/jaxrs/BeanParamInjectParamExtention.java
@@ -1,6 +1,7 @@
 package com.github.kongchen.swagger.docgen.jaxrs;
 
 import com.github.kongchen.swagger.docgen.reader.JaxrsReader;
+import com.google.common.collect.Lists;
 import com.sun.jersey.api.core.InjectParam;
 import com.sun.jersey.core.header.FormDataContentDisposition;
 import io.swagger.jaxrs.ext.AbstractSwaggerExtension;
@@ -28,25 +29,25 @@ import java.util.Set;
  * This extension extracts the parameters inside a {@code @BeanParam} by
  * expanding the target bean type's fields/methods/constructor parameters and
  * recursively feeding them back through the {@link JaxrsReader}.
- * 
+ *
  * @author chekong on 15/5/9.
  */
 public class BeanParamInjectParamExtention extends AbstractSwaggerExtension {
-    
+
     private static final AccessibleObjectGetter<Field> FIELD_GETTER = new AccessibleObjectGetter<Field>() {
         @Override
         public Field[] get(Class<?> clazz) {
             return clazz.getDeclaredFields();
         }
     };
-    
+
     private static final AccessibleObjectGetter<Method> METHOD_GETTER = new AccessibleObjectGetter<Method>() {
         @Override
         public Method[] get(Class<?> clazz) {
             return clazz.getDeclaredMethods();
         }
     };
-    
+
     private static final AccessibleObjectGetter<Constructor<?>> CONSTRUCTOR_GETTER = new AccessibleObjectGetter<Constructor<?>>() {
         @Override
         public Constructor<?>[] get(Class<?> clazz) {
@@ -55,11 +56,11 @@ public class BeanParamInjectParamExtention extends AbstractSwaggerExtension {
     };
 
     private final JaxrsReader reader;
-    
+
     public BeanParamInjectParamExtention(JaxrsReader reader) {
         this.reader = reader;
     }
-    
+
     @Override
     public List<Parameter> extractParameters(List<Annotation> annotations, Type type, Set<Type> typesToSkip, Iterator<SwaggerExtension> chain) {
         Class<?> cls = TypeUtils.getRawType(type, type);
@@ -67,7 +68,7 @@ public class BeanParamInjectParamExtention extends AbstractSwaggerExtension {
         if (shouldIgnoreClass(cls) || typesToSkip.contains(type)) {
             // stop the processing chain
             typesToSkip.add(type);
-            return Collections.emptyList();
+            return Lists.newArrayList();
         }
         for (Annotation annotation : annotations) {
             if (annotation instanceof BeanParam || annotation instanceof InjectParam) {
@@ -77,19 +78,19 @@ public class BeanParamInjectParamExtention extends AbstractSwaggerExtension {
         if (chain.hasNext()) {
             return chain.next().extractParameters(annotations, type, typesToSkip, chain);
         }
-        return Collections.emptyList();
+        return Lists.newArrayList();
     }
 
     private List<Parameter> extractParameters(Class<?> cls, Set<Type> typesToSkip) {
-        
+
         Collection<TypeWithAnnotations> typesWithAnnotations = new ArrayList<TypeWithAnnotations>();
-        
+
         for (Field field : getDeclaredAndInheritedMembers(cls, FIELD_GETTER)) {
             Type type = field.getGenericType();
             List<Annotation> annotations = Arrays.asList(field.getAnnotations());
             typesWithAnnotations.add(new TypeWithAnnotations(type, annotations));
         }
-        
+
         /*
          * For methods we will only examine setters and will only look at the
          * annotations on the parameter, not the method itself.
@@ -105,23 +106,23 @@ public class BeanParamInjectParamExtention extends AbstractSwaggerExtension {
             List<Annotation> annotations = Arrays.asList(JaxrsReader.findParamAnnotations(method)[0]);
             typesWithAnnotations.add(new TypeWithAnnotations(type, annotations));
         }
-        
+
         for (Constructor<?> constructor : getDeclaredAndInheritedMembers(cls, CONSTRUCTOR_GETTER)) {
-            
+
             Type[] parameterTypes = constructor.getGenericParameterTypes();
             Annotation[][] parameterAnnotations = constructor.getParameterAnnotations();
-            
+
             for (int i = 0; i < parameterTypes.length; i++) {
                 Type type = parameterTypes[i];
                 List<Annotation> annotations = Arrays.asList(parameterAnnotations[i]);
                 typesWithAnnotations.add(new TypeWithAnnotations(type, annotations));
             }
         }
-        
+
         List<Parameter> output = new ArrayList<Parameter>();
-        
+
         for (TypeWithAnnotations typeWithAnnotations : typesWithAnnotations) {
-            
+
             Type type = typeWithAnnotations.getType();
             List<Annotation> annotations = typeWithAnnotations.getAnnotations();
 
@@ -129,14 +130,14 @@ public class BeanParamInjectParamExtention extends AbstractSwaggerExtension {
              * Skip the type of the bean itself when recursing into its members
              * in order to avoid a cycle (stack overflow), as crazy as that user
              * code would have to be.
-             * 
+             *
              * There are no tests to prove this works because the test bean
              * classes are shared with SwaggerReaderTest and Swagger's own logic
              * doesn't prevent this problem.
              */
             Set<Type> recurseTypesToSkip = new HashSet<Type>(typesToSkip);
             recurseTypesToSkip.add(cls);
-            
+
             output.addAll(reader.getParameters(type, annotations, recurseTypesToSkip));
         }
 
@@ -157,10 +158,10 @@ public class BeanParamInjectParamExtention extends AbstractSwaggerExtension {
         }
         return fields;
     }
-    
+
     // get rid of this and use lambdas instead once Java 8 is supported
     private interface AccessibleObjectGetter<T extends AccessibleObject> {
-        
+
         T[] get(Class<?> clazz);
     }
 
@@ -168,16 +169,16 @@ public class BeanParamInjectParamExtention extends AbstractSwaggerExtension {
 
         private final Type type;
         private final List<Annotation> annotations;
-        
+
         TypeWithAnnotations(Type type, List<Annotation> annotations) {
             this.type = type;
             this.annotations = annotations;
         }
-        
+
         public Type getType() {
             return type;
         }
-        
+
         public List<Annotation> getAnnotations() {
             return annotations;
         }

--- a/src/main/java/com/github/kongchen/swagger/docgen/jaxrs/JaxrsParameterExtension.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/jaxrs/JaxrsParameterExtension.java
@@ -1,5 +1,6 @@
 package com.github.kongchen.swagger.docgen.jaxrs;
 
+import com.google.common.collect.Lists;
 import io.swagger.converter.ModelConverters;
 import io.swagger.jaxrs.ext.AbstractSwaggerExtension;
 import io.swagger.jaxrs.ext.SwaggerExtension;
@@ -20,10 +21,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * @author chekong on 15/5/12.
@@ -45,11 +43,11 @@ public class JaxrsParameterExtension extends AbstractSwaggerExtension {
             parameters.add(parameter);
         }
 
-        if (chain.hasNext()) {
-            return chain.next().extractParameters(annotations, type, typesToSkip, chain);
+        if (!parameters.isEmpty()) {
+            return parameters;
         }
-
-        return parameters;
+        super.extractParameters(annotations, type, typesToSkip, chain);
+        return Lists.newArrayList();
     }
 
     public static SerializableParameter getParameter(Type type, SerializableParameter parameter, Annotation annotation) {

--- a/src/main/java/com/github/kongchen/swagger/docgen/jaxrs/JaxrsParameterExtension.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/jaxrs/JaxrsParameterExtension.java
@@ -46,7 +46,9 @@ public class JaxrsParameterExtension extends AbstractSwaggerExtension {
         if (!parameters.isEmpty()) {
             return parameters;
         }
-        super.extractParameters(annotations, type, typesToSkip, chain);
+        if (chain.hasNext()) {
+            return chain.next().extractParameters(annotations, type, typesToSkip, chain);
+        }
         return Lists.newArrayList();
     }
 

--- a/src/main/java/com/github/kongchen/swagger/docgen/jaxrs/JaxrsParameterExtension.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/jaxrs/JaxrsParameterExtension.java
@@ -1,27 +1,18 @@
 package com.github.kongchen.swagger.docgen.jaxrs;
 
-import com.google.common.collect.Lists;
 import io.swagger.converter.ModelConverters;
 import io.swagger.jaxrs.ext.AbstractSwaggerExtension;
 import io.swagger.jaxrs.ext.SwaggerExtension;
-import io.swagger.models.parameters.CookieParameter;
-import io.swagger.models.parameters.FormParameter;
-import io.swagger.models.parameters.HeaderParameter;
-import io.swagger.models.parameters.Parameter;
-import io.swagger.models.parameters.PathParameter;
-import io.swagger.models.parameters.QueryParameter;
-import io.swagger.models.parameters.SerializableParameter;
+import io.swagger.models.parameters.*;
 import io.swagger.models.properties.Property;
 
-import javax.ws.rs.CookieParam;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.FormParam;
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.QueryParam;
+import javax.ws.rs.*;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 
 /**
  * @author chekong on 15/5/12.
@@ -46,10 +37,7 @@ public class JaxrsParameterExtension extends AbstractSwaggerExtension {
         if (!parameters.isEmpty()) {
             return parameters;
         }
-        if (chain.hasNext()) {
-            return chain.next().extractParameters(annotations, type, typesToSkip, chain);
-        }
-        return Lists.newArrayList();
+        return super.extractParameters(annotations, type, typesToSkip, chain);
     }
 
     public static SerializableParameter getParameter(Type type, SerializableParameter parameter, Annotation annotation) {

--- a/src/main/java/com/github/kongchen/swagger/docgen/jaxrs/JaxrsParameterExtension.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/jaxrs/JaxrsParameterExtension.java
@@ -45,6 +45,10 @@ public class JaxrsParameterExtension extends AbstractSwaggerExtension {
             parameters.add(parameter);
         }
 
+        if (chain.hasNext()) {
+            return chain.next().extractParameters(annotations, type, typesToSkip, chain);
+        }
+
         return parameters;
     }
 

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
@@ -1,73 +1,31 @@
 package com.github.kongchen.swagger.docgen.reader;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import javax.ws.rs.BeanParam;
-import javax.ws.rs.FormParam;
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.QueryParam;
-
-import org.apache.commons.lang3.reflect.TypeUtils;
-import org.apache.maven.plugin.logging.Log;
-import org.springframework.core.annotation.AnnotationUtils;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
-
+import com.google.common.collect.Lists;
 import com.sun.jersey.api.core.InjectParam;
-
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiImplicitParam;
-import io.swagger.annotations.ApiImplicitParams;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
-import io.swagger.annotations.Authorization;
-import io.swagger.annotations.AuthorizationScope;
-import io.swagger.annotations.Extension;
-import io.swagger.annotations.ExtensionProperty;
-import io.swagger.annotations.ResponseHeader;
+import io.swagger.annotations.*;
 import io.swagger.converter.ModelConverters;
 import io.swagger.jaxrs.ext.SwaggerExtension;
 import io.swagger.jaxrs.ext.SwaggerExtensions;
-import io.swagger.models.Model;
-import io.swagger.models.Operation;
+import io.swagger.models.*;
 import io.swagger.models.Path;
-import io.swagger.models.Response;
-import io.swagger.models.Scheme;
-import io.swagger.models.SecurityRequirement;
-import io.swagger.models.Swagger;
 import io.swagger.models.Tag;
-import io.swagger.models.parameters.BodyParameter;
-import io.swagger.models.parameters.FormParameter;
-import io.swagger.models.parameters.HeaderParameter;
-import io.swagger.models.parameters.Parameter;
-import io.swagger.models.parameters.PathParameter;
-import io.swagger.models.parameters.QueryParameter;
+import io.swagger.models.parameters.*;
 import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.MapProperty;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.RefProperty;
 import io.swagger.util.ParameterProcessor;
 import io.swagger.util.PathUtils;
+import org.apache.commons.lang3.reflect.TypeUtils;
+import org.apache.maven.plugin.logging.Log;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.web.bind.annotation.*;
+
+import javax.ws.rs.*;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.*;
 
 /**
  * @author chekong on 15/4/28.
@@ -382,7 +340,7 @@ public abstract class AbstractReader {
 
         return hasValidAnnotation;
     }
-    
+
     // this is final to enforce that only the implementation method below can be overridden, to avoid confusion
     protected final List<Parameter> getParameters(Type type, List<Annotation> annotations) {
         return getParameters(type, annotations, typesToSkip);
@@ -411,6 +369,8 @@ public abstract class AbstractReader {
             }
         } else {
             LOG.debug("Looking for body params in " + cls);
+            // parameters is guaranteed to be empty at this point, replace it with a mutable collection
+            parameters = Lists.newArrayList();
             if (!typesToSkip.contains(type)) {
                 Parameter param = ParameterProcessor.applyAnnotations(swagger, null, type, annotations);
                 if (param != null) {

--- a/src/main/java/com/github/kongchen/swagger/docgen/spring/SpringSwaggerExtension.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/spring/SpringSwaggerExtension.java
@@ -61,6 +61,10 @@ public class SpringSwaggerExtension extends AbstractSwaggerExtension {
             }
         }
 
+        if (chain.hasNext()) {
+            return chain.next().extractParameters(annotations, type, typesToSkip, chain);
+        }
+
         return parameters;
     }
 

--- a/src/main/java/com/github/kongchen/swagger/docgen/spring/SpringSwaggerExtension.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/spring/SpringSwaggerExtension.java
@@ -1,17 +1,11 @@
 package com.github.kongchen.swagger.docgen.spring;
 
 import com.fasterxml.jackson.databind.JavaType;
-import com.google.common.collect.Lists;
 import io.swagger.annotations.ApiParam;
 import io.swagger.converter.ModelConverters;
 import io.swagger.jaxrs.ext.AbstractSwaggerExtension;
 import io.swagger.jaxrs.ext.SwaggerExtension;
-import io.swagger.models.parameters.CookieParameter;
-import io.swagger.models.parameters.FormParameter;
-import io.swagger.models.parameters.HeaderParameter;
-import io.swagger.models.parameters.Parameter;
-import io.swagger.models.parameters.PathParameter;
-import io.swagger.models.parameters.QueryParameter;
+import io.swagger.models.parameters.*;
 import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.FileProperty;
 import io.swagger.models.properties.Property;
@@ -19,19 +13,17 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.TypeUtils;
 import org.springframework.beans.BeanUtils;
 import org.springframework.core.annotation.AnnotationUtils;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.beans.PropertyDescriptor;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 
 /**
  * @author chekong on 15/4/27.
@@ -62,10 +54,7 @@ public class SpringSwaggerExtension extends AbstractSwaggerExtension {
         if (!parameters.isEmpty()) {
             return parameters;
         }
-        if (chain.hasNext()) {
-            return chain.next().extractParameters(annotations, type, typesToSkip, chain);
-        }
-        return Lists.newArrayList();
+        return super.extractParameters(annotations, type, typesToSkip, chain);
     }
 
     private Parameter extractParameterFromAnnotation(Annotation annotation, String defaultValue, Type type) {

--- a/src/main/java/com/github/kongchen/swagger/docgen/spring/SpringSwaggerExtension.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/spring/SpringSwaggerExtension.java
@@ -62,7 +62,9 @@ public class SpringSwaggerExtension extends AbstractSwaggerExtension {
         if (!parameters.isEmpty()) {
             return parameters;
         }
-        super.extractParameters(annotations, type, typesToSkip, chain);
+        if (chain.hasNext()) {
+            return chain.next().extractParameters(annotations, type, typesToSkip, chain);
+        }
         return Lists.newArrayList();
     }
 

--- a/src/main/java/com/github/kongchen/swagger/docgen/spring/SpringSwaggerExtension.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/spring/SpringSwaggerExtension.java
@@ -1,6 +1,7 @@
 package com.github.kongchen.swagger.docgen.spring;
 
 import com.fasterxml.jackson.databind.JavaType;
+import com.google.common.collect.Lists;
 import io.swagger.annotations.ApiParam;
 import io.swagger.converter.ModelConverters;
 import io.swagger.jaxrs.ext.AbstractSwaggerExtension;
@@ -30,10 +31,7 @@ import java.beans.PropertyDescriptor;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * @author chekong on 15/4/27.
@@ -61,11 +59,11 @@ public class SpringSwaggerExtension extends AbstractSwaggerExtension {
             }
         }
 
-        if (chain.hasNext()) {
-            return chain.next().extractParameters(annotations, type, typesToSkip, chain);
+        if (!parameters.isEmpty()) {
+            return parameters;
         }
-
-        return parameters;
+        super.extractParameters(annotations, type, typesToSkip, chain);
+        return Lists.newArrayList();
     }
 
     private Parameter extractParameterFromAnnotation(Annotation annotation, String defaultValue, Type type) {

--- a/src/test/java/com/github/kongchen/swagger/docgen/IncludedSwaggerExtensionTest.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/IncludedSwaggerExtensionTest.java
@@ -1,30 +1,24 @@
-package com.github.kongchen.swagger.docgen.reader;
+package com.github.kongchen.swagger.docgen;
 
 import com.github.kongchen.swagger.docgen.jaxrs.BeanParamInjectParamExtention;
 import com.github.kongchen.swagger.docgen.jaxrs.JaxrsParameterExtension;
+import com.github.kongchen.swagger.docgen.reader.JaxrsReader;
 import com.github.kongchen.swagger.docgen.spring.SpringSwaggerExtension;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
-import com.google.common.reflect.ClassPath;
-import com.wordnik.sample.TestVendorExtension;
 import io.swagger.jaxrs.ext.AbstractSwaggerExtension;
 import io.swagger.jaxrs.ext.SwaggerExtension;
 import io.swagger.models.parameters.Parameter;
-import org.mockito.ArgumentMatcher;
-import org.mockito.Matchers;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import javax.swing.text.html.HTMLDocument;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.util.*;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 
 import static org.mockito.Mockito.*;
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Test class which ensures common functionality across all of the currently included Swagger Extensions, namely </p>
@@ -57,16 +51,6 @@ public class IncludedSwaggerExtensionTest {
             AbstractSwaggerExtension extension = mock(AbstractSwaggerExtension.class, CALLS_REAL_METHODS);
             Iterator<SwaggerExtension> iterator = Lists.<SwaggerExtension>newArrayList(extension).iterator();
 
-            // By default, AbstractSwaggerExtension.extractParameter returns an immutable collection
-            // This is not desirable for this test, since in the real world every extension should return a modifiable one.
-            // To ensure compatibly with other, third party extensions
-            when(extension.extractParameters(
-                    annotations,
-                    Void.TYPE,
-                    typesToSkip,
-                    iterator)
-            ).thenReturn(Lists.<Parameter>newArrayList());
-
             // Not possible to add any parameters for the extensions, since no annotation / field is given to the extensions
             // only the previously created mock AbstractSwaggerExtension is in the chain
             // This allows to test if first the chain is called, and only then empty, modifiable lists are returned as last resort
@@ -86,8 +70,6 @@ public class IncludedSwaggerExtensionTest {
                         anySetOf(Type.class),
                         eq(iterator)
                 );
-                // This will throw an exception if the parameters list is not modifiable, thus failing this test
-                parameters.add(null);
             } catch (Throwable t) {
                 // Catch everything here.
                 // We need to output the currently tested extension here

--- a/src/test/java/com/github/kongchen/swagger/docgen/jaxrs/JaxrsParameterExtensionTest.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/jaxrs/JaxrsParameterExtensionTest.java
@@ -1,0 +1,41 @@
+package com.github.kongchen.swagger.docgen.jaxrs;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import io.swagger.jaxrs.ext.SwaggerExtension;
+import io.swagger.models.parameters.Parameter;
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.QueryParam;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+public class JaxrsParameterExtensionTest {
+    @Test
+    public void testExtractParametersReturnsRetrievedParameters() {
+        List<Parameter> parameters = new JaxrsParameterExtension().extractParameters(
+                Lists.newArrayList(getTestAnnotation()),
+                String.class,
+                Sets.<Type>newHashSet(),
+                Lists.<SwaggerExtension>newArrayList().iterator());
+
+        assertFalse(parameters.isEmpty());
+        assertEquals(parameters.size(), 1);
+    }
+
+    private Annotation getTestAnnotation() {
+        return MethodUtils.getMethodsWithAnnotation(SomeResource.class, QueryParam.class)[0].getAnnotation(QueryParam.class);
+    }
+
+    private static class SomeResource {
+        @QueryParam("lang")
+        public void get(String lang) {
+
+        }
+    }
+}

--- a/src/test/java/com/github/kongchen/swagger/docgen/jaxrs/JaxrsParameterExtensionTest.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/jaxrs/JaxrsParameterExtensionTest.java
@@ -35,7 +35,8 @@ public class JaxrsParameterExtensionTest {
     private static class SomeResource {
         @QueryParam("lang")
         public void get(String lang) {
-
+            // no implementation needed. Method is only for the test cases, so that the annotation QueryParam
+            // can easily be retrieved and used
         }
     }
 }

--- a/src/test/java/com/github/kongchen/swagger/docgen/reader/IncludedSwaggerExtensionTest.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/reader/IncludedSwaggerExtensionTest.java
@@ -1,0 +1,102 @@
+package com.github.kongchen.swagger.docgen.reader;
+
+import com.github.kongchen.swagger.docgen.jaxrs.BeanParamInjectParamExtention;
+import com.github.kongchen.swagger.docgen.jaxrs.JaxrsParameterExtension;
+import com.github.kongchen.swagger.docgen.spring.SpringSwaggerExtension;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.reflect.ClassPath;
+import com.wordnik.sample.TestVendorExtension;
+import io.swagger.jaxrs.ext.AbstractSwaggerExtension;
+import io.swagger.jaxrs.ext.SwaggerExtension;
+import io.swagger.models.parameters.Parameter;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import javax.swing.text.html.HTMLDocument;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.*;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+/**
+ * Test class which ensures common functionality across all of the currently included Swagger Extensions, namely </p>
+ * <ul>
+ *     <li>@{@link com.github.kongchen.swagger.docgen.spring.SpringSwaggerExtension}</li>
+ *     <li>{@link com.github.kongchen.swagger.docgen.jaxrs.JaxrsParameterExtension}</li>
+ *     <li>{@link com.github.kongchen.swagger.docgen.jaxrs.BeanParamInjectParamExtention}</li>
+ * </ul>
+ *
+ */
+public class IncludedSwaggerExtensionTest {
+    private static final List<AbstractSwaggerExtension> SWAGGER_EXTENSIONS = Lists.newArrayList();
+
+    static {
+        //TODO: Maybe use a Classpath Scanner to automatically figure out the included extensions?
+        SWAGGER_EXTENSIONS.add(new JaxrsParameterExtension());
+        SWAGGER_EXTENSIONS.add(new SpringSwaggerExtension());
+        SWAGGER_EXTENSIONS.add(new BeanParamInjectParamExtention(mock(JaxrsReader.class)));
+    }
+
+    @Test
+    /**
+     * This tests acts more like an integration test than a real unit test. It tests whether the extensions return
+     * generally correct values.
+     */
+    public void testExtractParametersReturnsEmptyList() {
+        for (AbstractSwaggerExtension swaggerExtension : SWAGGER_EXTENSIONS) {
+            Set<Type> typesToSkip = Collections.emptySet();
+            List<Annotation> annotations = Collections.emptyList();
+            AbstractSwaggerExtension extension = mock(AbstractSwaggerExtension.class, CALLS_REAL_METHODS);
+            Iterator<SwaggerExtension> iterator = Lists.<SwaggerExtension>newArrayList(extension).iterator();
+
+            // By default, AbstractSwaggerExtension.extractParameter returns an immutable collection
+            // This is not desirable for this test, since in the real world every extension should return a modifiable one.
+            // To ensure compatibly with other, third party extensions
+            when(extension.extractParameters(
+                    annotations,
+                    Void.TYPE,
+                    typesToSkip,
+                    iterator)
+            ).thenReturn(Lists.<Parameter>newArrayList());
+
+            // Not possible to add any parameters for the extensions, since no annotation / field is given to the extensions
+            // only the previously created mock AbstractSwaggerExtension is in the chain
+            // This allows to test if first the chain is called, and only then empty, modifiable lists are returned as last resort
+            List<Parameter> parameters = swaggerExtension.extractParameters(
+                    annotations,
+                    Void.TYPE,
+                    typesToSkip,
+                    iterator);
+
+            // returned parameters have to be empty since we gave the extension no real type to work with
+            assertTrue(parameters.isEmpty(), "Extension " + swaggerExtension.getClass().getName() + " did not return a modifiable list.");
+
+            try {
+                verify(extension).extractParameters(
+                        anyListOf(Annotation.class),
+                        any(Type.class),
+                        anySetOf(Type.class),
+                        eq(iterator)
+                );
+                // This will throw an exception if the parameters list is not modifiable, thus failing this test
+                parameters.add(null);
+            } catch (Throwable t) {
+                // Catch everything here.
+                // We need to output the currently tested extension here
+                // so that the reason why the test failed can be easier recognized later on
+                // Still need to rethrow the exception though, to make the test fail
+
+                // TODO: Is there any better wrapper exception type?
+                throw new IllegalStateException("Extension "+ swaggerExtension.getClass().getName() + " failed this Test.", t);
+            }
+        }
+    }
+}

--- a/src/test/java/com/github/kongchen/swagger/docgen/spring/SpringSwaggerExtensionTest.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/spring/SpringSwaggerExtensionTest.java
@@ -1,0 +1,42 @@
+package com.github.kongchen.swagger.docgen.spring;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.wordnik.sample.model.PaginationHelper;
+import io.swagger.jaxrs.ext.SwaggerExtension;
+import io.swagger.models.parameters.Parameter;
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.List;
+
+import static org.testng.Assert.assertFalse;
+
+public class SpringSwaggerExtensionTest {
+    @Test
+    public void testExtractParametersReturnsRetrievedParameters() {
+        List<Parameter> parameters = new SpringSwaggerExtension().extractParameters(
+                Lists.newArrayList(getTestAnnotation()),
+                PaginationHelper.class,
+                Sets.<Type>newHashSet(),
+                Lists.<SwaggerExtension>newArrayList().iterator());
+
+        assertFalse(parameters.isEmpty());
+        Assert.assertEquals(parameters.size(), 2);
+    }
+
+    private Annotation getTestAnnotation() {
+        return MethodUtils.getMethodsWithAnnotation(SpringSwaggerExtensionTest.SomeResource.class, ModelAttribute.class)[0].getAnnotation(ModelAttribute.class);
+    }
+
+    private static class SomeResource {
+        @ModelAttribute
+        public void get() {
+
+        }
+    }
+}

--- a/src/test/java/com/github/kongchen/swagger/docgen/spring/SpringSwaggerExtensionTest.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/spring/SpringSwaggerExtensionTest.java
@@ -36,7 +36,8 @@ public class SpringSwaggerExtensionTest {
     private static class SomeResource {
         @ModelAttribute
         public void get() {
-
+            // no implementation needed. Method is only for the test cases, so that the annotation ModelAttribute
+            // can easily be retrieved and used
         }
     }
 }


### PR DESCRIPTION
The default extensions, JaxrsParameterExtension
and SpringSwaggerExtension now call the next extension in the SwaggerExtensions.chain() iteration.
This enables third party extensions, specified by swaggerExtensions element, to be actually called and executed.