### PR TITLE
Multiple pom related updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>7</version>
-    </parent>
-
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.kongchen</groupId>
     <artifactId>swagger-maven-plugin</artifactId>
@@ -57,11 +51,18 @@
     </contributors>
 
     <properties>
-        <maven.version>2.2.1</maven.version>
-        <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
+        <!-- Settings -->
         <java.version>1.6</java.version>
-        <swagger.version>1.5.18</swagger.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
         <github.global.server>github</github.global.server>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <sonatypeOssDistMgmtSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</sonatypeOssDistMgmtSnapshotsUrl>
+
+        <!-- Dependency versions -->
+        <maven.version>2.2.1</maven.version>
+        <swagger.version>1.5.18</swagger.version>
         <jackson.version>2.8.9</jackson.version>
         <log4j.version>1.2.16</log4j.version>
         <handlebars.version>1.3.2</handlebars.version>
@@ -74,6 +75,16 @@
         <springframework.version>4.3.7.RELEASE</springframework.version>
         <commons-lang3.version>3.5</commons-lang3.version>
         <junit-addons.version>1.4</junit-addons.version>
+
+        <!-- Plugin versions -->
+        <version.maven-release-plugin>2.5.3</version.maven-release-plugin>
+        <version.plexus-component-metadata>1.5.5</version.plexus-component-metadata>
+        <version.maven-compiler-plugin>2.3.2</version.maven-compiler-plugin>
+        <version.maven-plugin-plugin>3.3</version.maven-plugin-plugin>
+        <version.animal-sniffer-plugin>1.14</version.animal-sniffer-plugin>
+        <version.maven-source-plugin>2.1.2</version.maven-source-plugin>
+        <version.maven-javadoc-plugin>2.7</version.maven-javadoc-plugin>
+        <version.maven-gpg-plugin>1.1</version.maven-gpg-plugin>
     </properties>
 
     <dependencies>
@@ -187,6 +198,7 @@
             <version>${jackson.version}</version>
         </dependency>
 
+        <!-- Test dependencies -->
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
@@ -239,17 +251,16 @@
     </dependencies>
 
     <build>
-
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
+                <version>${version.maven-release-plugin}</version>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-component-metadata</artifactId>
-                <version>1.5.5</version>
+                <version>${version.plexus-component-metadata}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -261,17 +272,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <encoding>UTF-8</encoding>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                </configuration>
+                <version>${version.maven-compiler-plugin}</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.3</version>
+                <version>${version.maven-plugin-plugin}</version>
                 <configuration>
                     <!-- see http://jira.codehaus.org/browse/MNG-5346 -->
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
@@ -295,7 +301,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>1.14</version>
+                <version>${version.animal-sniffer-plugin}</version>
                 <configuration>
                     <signature>
                         <groupId>org.codehaus.mojo.signature</groupId>
@@ -316,4 +322,81 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>sonatype-oss-release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>${version.maven-source-plugin}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>${version.maven-javadoc-plugin}</version>
+                        <configuration>
+                            <taglets>
+                                <taglet>
+                                    <tagletClass>org.codehaus.plexus.javadoc.PlexusComponentTaglet</tagletClass>
+                                    <tagletArtifact>
+                                        <groupId>org.codehaus.plexus</groupId>
+                                        <artifactId>plexus-javadoc</artifactId>
+                                        <version>1.0</version>
+                                    </tagletArtifact>
+                                </taglet>
+                                <taglet>
+                                    <tagletClass>org.codehaus.plexus.javadoc.PlexusConfigurationTaglet</tagletClass>
+                                    <tagletArtifact>
+                                        <groupId>org.codehaus.plexus</groupId>
+                                        <artifactId>plexus-javadoc</artifactId>
+                                        <version>1.0</version>
+                                    </tagletArtifact>
+                                </taglet>
+                                <taglet>
+                                    <tagletClass>org.codehaus.plexus.javadoc.PlexusRequirementTaglet</tagletClass>
+                                    <tagletArtifact>
+                                        <groupId>org.codehaus.plexus</groupId>
+                                        <artifactId>plexus-javadoc</artifactId>
+                                        <version>1.0</version>
+                                    </tagletArtifact>
+                                </taglet>
+                            </taglets>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>sonatype-nexus-snapshots</id>
+            <name>Sonatype Nexus Snapshots</name>
+            <url>${sonatypeOssDistMgmtSnapshotsUrl}</url>
+        </snapshotRepository>
+        <repository>
+            <id>sonatype-nexus-staging</id>
+            <name>Nexus Release Repository</name>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -231,15 +231,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit-addons</groupId>
-            <artifactId>junit-addons</artifactId>
-            <version>${junit-addons.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
+            <version>2.18.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -66,15 +66,20 @@
         <jackson.version>2.8.9</jackson.version>
         <log4j.version>1.2.16</log4j.version>
         <handlebars.version>1.3.2</handlebars.version>
+        <commons-io.version>2.0.1</commons-io.version>
+        <reflections.version>0.9.9</reflections.version>
+        <springframework.version>4.3.7.RELEASE</springframework.version>
+        <commons-lang3.version>3.5</commons-lang3.version>
+        <version.jersey-server>1.13</version.jersey-server>
+        <version.javax.ws.rs-api>2.0.1</version.javax.ws.rs-api>
+        <version.maven-plugin-annotations>3.3</version.maven-plugin-annotations>
+        <!-- Test dependency versions -->
+        <maven-testing-harness.version>1.3</maven-testing-harness.version>
         <testng.version>6.8.8</testng.version>
         <jettison.version>1.3.3</jettison.version>
         <json-unit.version>1.17.0</json-unit.version>
-        <commons-io.version>2.0.1</commons-io.version>
-        <reflections.version>0.9.9</reflections.version>
-        <maven-testing-harness.version>1.3</maven-testing-harness.version>
-        <springframework.version>4.3.7.RELEASE</springframework.version>
-        <commons-lang3.version>3.5</commons-lang3.version>
-        <junit-addons.version>1.4</junit-addons.version>
+        <version.mockito-core>2.18.3</version.mockito-core>
+        <version.hamcrest-library>1.3</version.hamcrest-library>
 
         <!-- Plugin versions -->
         <version.maven-release-plugin>2.5.3</version.maven-release-plugin>
@@ -85,6 +90,8 @@
         <version.maven-source-plugin>2.1.2</version.maven-source-plugin>
         <version.maven-javadoc-plugin>2.7</version.maven-javadoc-plugin>
         <version.maven-gpg-plugin>1.1</version.maven-gpg-plugin>
+        <version.plexus-javadoc>1.0</version.plexus-javadoc>
+        <version.slf4j-nop>1.7.25</version.slf4j-nop>
     </properties>
 
     <dependencies>
@@ -111,7 +118,17 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>2.0.9</version>
+            <version>${maven.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-nop</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-jdk14</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -154,7 +171,7 @@
         <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.0.1</version>
+            <version>${version.javax.ws.rs-api}</version>
         </dependency>
         <dependency>
             <groupId>io.swagger</groupId>
@@ -164,12 +181,12 @@
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-server</artifactId>
-            <version>1.13</version>
+            <version>${version.jersey-server}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.3</version>
+            <version>${version.maven-plugin-annotations}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -210,6 +227,12 @@
             <artifactId>maven-plugin-testing-harness</artifactId>
             <version>${maven-testing-harness.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-nop</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -233,13 +256,19 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.18.3</version>
+            <version>${version.mockito-core}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
-            <version>1.3</version>
+            <version>${version.hamcrest-library}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-nop</artifactId>
+            <version>${version.slf4j-nop}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -342,29 +371,19 @@
                             <taglets>
                                 <taglet>
                                     <tagletClass>org.codehaus.plexus.javadoc.PlexusComponentTaglet</tagletClass>
-                                    <tagletArtifact>
-                                        <groupId>org.codehaus.plexus</groupId>
-                                        <artifactId>plexus-javadoc</artifactId>
-                                        <version>1.0</version>
-                                    </tagletArtifact>
                                 </taglet>
                                 <taglet>
                                     <tagletClass>org.codehaus.plexus.javadoc.PlexusConfigurationTaglet</tagletClass>
-                                    <tagletArtifact>
-                                        <groupId>org.codehaus.plexus</groupId>
-                                        <artifactId>plexus-javadoc</artifactId>
-                                        <version>1.0</version>
-                                    </tagletArtifact>
                                 </taglet>
                                 <taglet>
                                     <tagletClass>org.codehaus.plexus.javadoc.PlexusRequirementTaglet</tagletClass>
-                                    <tagletArtifact>
-                                        <groupId>org.codehaus.plexus</groupId>
-                                        <artifactId>plexus-javadoc</artifactId>
-                                        <version>1.0</version>
-                                    </tagletArtifact>
                                 </taglet>
                             </taglets>
+                            <tagletArtifact>
+                                <groupId>org.codehaus.plexus</groupId>
+                                <artifactId>plexus-javadoc</artifactId>
+                                <version>${version.plexus-javadoc}</version>
+                            </tagletArtifact>
                         </configuration>
                         <executions>
                             <execution>
@@ -375,7 +394,20 @@
                             </execution>
                         </executions>
                     </plugin>
-
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>${version.maven-gpg-plugin}</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/src/main/java/com/github/kongchen/swagger/docgen/AbstractDocumentSource.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/AbstractDocumentSource.java
@@ -398,7 +398,7 @@ public abstract class AbstractDocumentSource {
     /**
      * Returns the set of classes which should be included in the scanning.
      *
-     * @return Set<Class<?>> containing all valid classes
+     * @return Set containing all valid classes
      */
     protected Set<Class<?>> getValidClasses() {
         return apiSource.getValidClasses(Api.class);
@@ -407,7 +407,7 @@ public abstract class AbstractDocumentSource {
     /**
      * Resolves all {@link SwaggerExtension} instances configured to be added to the Swagger configuration.
      *
-     * @return Collection<SwaggerExtension> which should be added to the swagger configuration
+     * @return List of {@link SwaggerExtension} which should be added to the swagger configuration
      * @throws GenerateException if the swagger extensions could not be created / resolved
      */
     protected List<SwaggerExtension> resolveSwaggerExtensions() throws GenerateException {

--- a/src/main/java/com/github/kongchen/swagger/docgen/spring/SpringResource.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/spring/SpringResource.java
@@ -1,12 +1,7 @@
 package com.github.kongchen.swagger.docgen.spring;
 
-import org.apache.commons.lang3.StringUtils;
-import org.springframework.core.annotation.AnnotationUtils;
-import org.springframework.web.bind.annotation.RequestMapping;
-
 import com.github.kongchen.swagger.docgen.util.SpringUtils;
-
-import edu.emory.mathcs.backport.java.util.Arrays;
+import org.apache.commons.lang3.StringUtils;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -24,8 +19,11 @@ public class SpringResource {
     private String description;
 
     /**
-     * @param clazz        (Class<?>) Controller class
+     *
+     * @param clazz        Controller class
      * @param resourceName resource Name
+     * @param resourceKey key containing the controller package, class controller class name, and controller-level @RequestMapping#value
+     * @param description description of the contrroller
      */
     public SpringResource(Class<?> clazz, String resourceName, String resourceKey, String description) {
         this.controllerClass = clazz;

--- a/src/main/java/com/github/kongchen/swagger/docgen/util/SpringUtils.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/util/SpringUtils.java
@@ -3,56 +3,12 @@ package com.github.kongchen.swagger.docgen.util;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import com.google.common.base.CharMatcher;
-
 /**
  * @author kongchen
  *         Date: 1/21/14
  * @author tedleman
  */
 public class SpringUtils {
-
-    /**
-     * Create a resource key from name and version
-     *
-     * @param resourceName
-     * @param version
-     * @return
-     */
-    public static String createResourceKey(String resourceName, String version) {
-        String resourceKey;
-        if (!version.isEmpty()) {
-            resourceKey = resourceName + "." + version;
-        } else {
-            resourceKey = resourceName;
-        }
-        resourceKey = CharMatcher.anyOf("%^#?:;").removeFrom(resourceKey);
-        return resourceKey;
-    }
-
-    /**
-     * @param mapping
-     * @return version of resource
-     */
-    public static String parseVersion(String mapping) {
-        String version = "";
-        String[] mappingArray = mapping.split("/");
-
-        for (String str : mappingArray) {
-            if (str.length() < 4) {
-                for (char c : str.toCharArray()) {
-                    if (Character.isDigit(c)) {
-                        version = str;
-                        break;
-                    }
-                }
-            }
-
-        }
-
-        return version;
-    }
-
     /**
      * Extracts all routes from the annotated class
      *


### PR DESCRIPTION
Initiator of these changes was that [oss-parent is deprecated](https://github.com/sonatype/oss-parents#sonatype-oss-parent-poms---oss-parents). Reasioning for this is that [This project leaked SCM, URL and other details](http://central.sonatype.org/pages/apache-maven.html#deprecated-oss-parent).

I included everything that was in the oss-parent pom into our own one. Profiles stay the same, sonatype-oss-release for deployment on ossrh.

I took this oppurtinity to clean the pom up a bit, by moving the plugin versions to the `properties` sections, and some other settings there.

I also fixed all of the current javadoc errors. They were just ignored before (property `maven.javadoc.failOnError`).

Mockito was updated to the newest core version. The core versions don't include hamcrest and objenesis anymore, making dependency management a bit easier.

junit-addons was removed in favour of using guava methods, and a normal assert.
