### PR TITLE
Fix Securitydefinitions having wrong name

### DIFF
--- a/src/test/java/com/github/kongchen/swagger/docgen/mavenplugin/SecurityDefinitionTest.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/mavenplugin/SecurityDefinitionTest.java
@@ -1,0 +1,38 @@
+package com.github.kongchen.swagger.docgen.mavenplugin;
+
+import com.github.kongchen.swagger.docgen.GenerateException;
+import io.swagger.models.auth.ApiKeyAuthDefinition;
+import io.swagger.models.auth.OAuth2Definition;
+import io.swagger.models.auth.SecuritySchemeDefinition;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+public class SecurityDefinitionTest {
+    @Test
+    public void testSecurityDefinitionRetainsWantedName() throws GenerateException {
+        SecurityDefinition definition = new SecurityDefinition();
+        definition.setJson("securityDefinition.json");
+
+        Map<String, SecuritySchemeDefinition> definitions = definition.generateSecuritySchemeDefinitions();
+
+        SecuritySchemeDefinition api_key = definitions.get("api_key");
+        Assert.assertNotNull(api_key);
+        Assert.assertTrue(api_key instanceof ApiKeyAuthDefinition);
+        Assert.assertEquals(((ApiKeyAuthDefinition)api_key).getName(), "api_key_name");
+
+        // No name is set for this auth
+        // The name should be set to the name of the definition
+        // So that the name is never actually empty
+        SecuritySchemeDefinition api_key_empty_name = definitions.get("api_key_empty_name");
+        Assert.assertNotNull(api_key_empty_name);
+        Assert.assertTrue(api_key_empty_name instanceof ApiKeyAuthDefinition);
+        Assert.assertEquals(((ApiKeyAuthDefinition)api_key_empty_name).getName(), "api_key_empty_name");
+
+
+        SecuritySchemeDefinition petstore_auth = definitions.get("petstore_auth");
+        Assert.assertNotNull(petstore_auth);
+        Assert.assertTrue(petstore_auth instanceof OAuth2Definition);
+    }
+}

--- a/src/test/resources/com/github/kongchen/swagger/docgen/mavenplugin/securityDefinition.json
+++ b/src/test/resources/com/github/kongchen/swagger/docgen/mavenplugin/securityDefinition.json
@@ -1,0 +1,20 @@
+{
+    "api_key": {
+        "type": "apiKey",
+        "name": "api_key_name",
+        "in": "header"
+    },
+    "api_key_empty_name": {
+        "type": "apiKey",
+        "in": "header"
+    },
+    "petstore_auth": {
+        "type": "oauth2",
+        "authorizationUrl": "http://swagger.io/api/oauth/dialog",
+        "flow": "implicit",
+        "scopes": {
+            "write:pets": "modify pets in your account",
+            "read:pets": "read your pets"
+        }
+    }
+}


### PR DESCRIPTION
This prevents the name field being used as overall name of the definition itself.
fixes #616