### PR TITLE
Add support for extensions on Info level

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiSource.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiSource.java
@@ -1,28 +1,24 @@
 package com.github.kongchen.swagger.docgen.mavenplugin;
 
-import java.io.File;
-import java.lang.annotation.Annotation;
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
-
+import io.swagger.annotations.SwaggerDefinition;
+import io.swagger.models.Contact;
+import io.swagger.models.Info;
+import io.swagger.models.License;
+import io.swagger.util.BaseReaderUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.reflections.Reflections;
 import org.springframework.core.annotation.AnnotationUtils;
 
-import io.swagger.annotations.SwaggerDefinition;
-import io.swagger.models.Contact;
-import io.swagger.models.Info;
-import io.swagger.models.License;
+import java.io.File;
+import java.lang.annotation.Annotation;
+import java.util.*;
 
 /**
  * User: kongchen
  * Date: 3/7/13
  */
 public class ApiSource {
-
     /**
      * Java classes containing Swagger's annotation <code>@Api</code>, or Java packages containing those classes
      * can be configured here.
@@ -192,12 +188,19 @@ public class ApiSource {
         for (Class<?> aClass : getValidClasses(SwaggerDefinition.class)) {
             SwaggerDefinition swaggerDefinition = AnnotationUtils.findAnnotation(aClass, SwaggerDefinition.class);
             io.swagger.annotations.Info infoAnnotation = swaggerDefinition.info();
+
             Info info = new Info().title(infoAnnotation.title())
                     .description(emptyToNull(infoAnnotation.description()))
                     .version(infoAnnotation.version())
                     .termsOfService(emptyToNull(infoAnnotation.termsOfService()))
                     .license(from(infoAnnotation.license()))
                     .contact(from(infoAnnotation.contact()));
+
+            Map<String, Object> customExtensions = BaseReaderUtils.parseExtensions(infoAnnotation.extensions());
+            for (Map.Entry<String, Object> extension : customExtensions.entrySet()) {
+                resultInfo.setVendorExtension(extension.getKey(), extension.getValue());
+            }
+
             resultInfo.mergeWith(info);
         }
         info = resultInfo;

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
@@ -138,34 +138,6 @@ public abstract class AbstractReader {
         return responseHeaders;
     }
 
-    protected Set<Map<String, Object>> parseCustomExtensions(Extension[] extensions) {
-        if (extensions == null) {
-            return Collections.emptySet();
-        }
-        Set<Map<String, Object>> resultSet = new HashSet<Map<String, Object>>();
-        for (Extension extension : extensions) {
-            if (extension == null) {
-                continue;
-            }
-            Map<String, Object> extensionProperties = new HashMap<String, Object>();
-            for (ExtensionProperty extensionProperty : extension.properties()) {
-                String name = extensionProperty.name();
-                if (!name.isEmpty()) {
-                    String value = extensionProperty.value();
-                    extensionProperties.put(name, value);
-                }
-            }
-            if (!extension.name().isEmpty()) {
-                Map<String, Object> wrapper = new HashMap<String, Object>();
-                wrapper.put(extension.name(), extensionProperties);
-                resultSet.add(wrapper);
-            } else {
-                resultSet.add(extensionProperties);
-            }
-        }
-        return resultSet;
-    }
-
     protected void updatePath(String operationPath, String httpMethod, Operation operation) {
         if (httpMethod == null) {
             return;

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiReader.java
@@ -4,23 +4,16 @@ import com.github.kongchen.swagger.docgen.GenerateException;
 import com.github.kongchen.swagger.docgen.spring.SpringResource;
 import com.github.kongchen.swagger.docgen.spring.SpringSwaggerExtension;
 import com.github.kongchen.swagger.docgen.util.SpringUtils;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponses;
-import io.swagger.annotations.Authorization;
-import io.swagger.annotations.AuthorizationScope;
+import io.swagger.annotations.*;
 import io.swagger.converter.ModelConverters;
 import io.swagger.jaxrs.ext.SwaggerExtension;
 import io.swagger.jaxrs.ext.SwaggerExtensions;
-import io.swagger.models.Model;
-import io.swagger.models.Operation;
-import io.swagger.models.Response;
-import io.swagger.models.SecurityRequirement;
-import io.swagger.models.Swagger;
+import io.swagger.models.*;
 import io.swagger.models.Tag;
 import io.swagger.models.parameters.Parameter;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.RefProperty;
+import io.swagger.util.BaseReaderUtils;
 import org.apache.maven.plugin.logging.Log;
 import org.codehaus.plexus.util.StringUtils;
 import org.springframework.core.DefaultParameterNameDiscoverer;
@@ -33,12 +26,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 import static org.springframework.core.annotation.AnnotatedElementUtils.findMergedAnnotation;
@@ -178,20 +166,8 @@ public class SpringMvcApiReader extends AbstractReader implements ClassSwaggerRe
 
             operation.summary(apiOperation.value()).description(apiOperation.notes());
 
-            Set<Map<String, Object>> customExtensions = parseCustomExtensions(apiOperation.extensions());
-
-            for (Map<String, Object> extension : customExtensions) {
-                if (extension == null) {
-                    continue;
-                }
-                for (Map.Entry<String, Object> map : extension.entrySet()) {
-                    operation.setVendorExtension(
-                            map.getKey().startsWith("x-")
-                                    ? map.getKey()
-                                    : "x-" + map.getKey(), map.getValue()
-                    );
-                }
-            }
+            Map<String, Object> customExtensions = BaseReaderUtils.parseExtensions(apiOperation.extensions());
+            operation.setVendorExtensions(customExtensions);
 
             if (!apiOperation.response().equals(Void.class)) {
                 responseClass = apiOperation.response();

--- a/src/test/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiSourceTest.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiSourceTest.java
@@ -1,0 +1,69 @@
+package com.github.kongchen.swagger.docgen.mavenplugin;
+
+import com.google.common.collect.Sets;
+import io.swagger.annotations.Extension;
+import io.swagger.annotations.ExtensionProperty;
+import io.swagger.annotations.SwaggerDefinition;
+import io.swagger.models.Info;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class ApiSourceTest {
+
+    @Spy
+    protected ApiSource apiSource;
+
+    @BeforeMethod
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testGetInfo0VendorExtensions() {
+        Map<String, Object> expectedExtensions = new HashMap<String, Object>();
+        expectedExtensions.put("x-logo", new HashMap<String, Object>(){{
+            put("logo", "logo url");
+            put("description", "This is our logo.");
+        }});
+        expectedExtensions.put("x-website", new HashMap<String, Object>(){{
+            put("website", "website url");
+            put("description", "This is our website.");
+        }});
+
+
+        Set<Class<?>> validClasses = Sets.newHashSet(ApiSourceTestClass.class);
+
+        Mockito.when(apiSource.getValidClasses(SwaggerDefinition.class)).thenReturn(validClasses);
+        Info info = apiSource.getInfo();
+
+        Map<String, Object> vendorExtensions = info.getVendorExtensions();
+        Assert.assertEquals(vendorExtensions.size(), 2);
+        Assert.assertEquals(vendorExtensions, expectedExtensions);
+    }
+
+    @SwaggerDefinition(info = @io.swagger.annotations.Info(
+            title = "ApiSourceTestClass",
+            version = "1.0.0",
+            extensions = {
+                    @Extension(name = "logo", properties = {
+                            @ExtensionProperty(name = "logo", value = "logo url"),
+                            @ExtensionProperty(name = "description", value = "This is our logo.")
+                    }),
+                    @Extension(name = "website", properties = {
+                            @ExtensionProperty(name = "website", value = "website url"),
+                            @ExtensionProperty(name = "description", value = "This is our website.")
+                    })
+            }
+    ))
+    private static class ApiSourceTestClass {
+
+    }
+}

--- a/src/test/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiSourceTest.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiSourceTest.java
@@ -28,15 +28,17 @@ public class ApiSourceTest {
 
     @Test
     public void testGetInfo0VendorExtensions() {
+        Map<String, Object> logo = new HashMap<String, Object>();
+        logo.put("logo", "logo url");
+        logo.put("description", "This is our logo.");
+
+        Map<String, Object> website = new HashMap<String, Object>();
+        website.put("website", "website url");
+        website.put("description", "This is our website.");
+
         Map<String, Object> expectedExtensions = new HashMap<String, Object>();
-        expectedExtensions.put("x-logo", new HashMap<String, Object>(){{
-            put("logo", "logo url");
-            put("description", "This is our logo.");
-        }});
-        expectedExtensions.put("x-website", new HashMap<String, Object>(){{
-            put("website", "website url");
-            put("description", "This is our website.");
-        }});
+        expectedExtensions.put("x-logo", logo);
+        expectedExtensions.put("x-website", website);
 
 
         Set<Class<?>> validClasses = Sets.newHashSet(ApiSourceTestClass.class);


### PR DESCRIPTION
This makes it possible to define Verndor specific extensions on the Info Part of the @SwaggerDefinition
Also, do some cleanup.

closes #617 