### PR TITLE
Ignore case when sorting tags

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/Utils.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/Utils.java
@@ -96,7 +96,7 @@ public class Utils {
         if (swagger.getTags() != null) {
             Collections.sort(swagger.getTags(), new Comparator<Tag>() {
                 public int compare(final Tag a, final Tag b) {
-                    return a.toString().compareTo(b.toString());
+                    return a.toString().toLowerCase().compareTo(b.toString().toLowerCase());
                 }
             });
         }


### PR DESCRIPTION
Likely most would prefer alphabetical over ASCIIbetical.