### PR TITLE
Fix body parameter for octect-stream and byte[] parameter #2

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
@@ -117,7 +117,7 @@ public abstract class AbstractReader {
     }
 
     protected List<SecurityRequirement> getSecurityRequirements(Api api) {
-        List<SecurityRequirement> securities = new ArrayList<SecurityRequirement>();
+        List<SecurityRequirement> securities = new ArrayList<>();
         if(api == null) {
             return securities;
         }
@@ -166,7 +166,7 @@ public abstract class AbstractReader {
                 continue;
             }
             if (responseHeaders == null) {
-                responseHeaders = new HashMap<String, Property>();
+                responseHeaders = new HashMap<>();
             }
             Class<?> cls = header.response();
 
@@ -219,7 +219,7 @@ public abstract class AbstractReader {
     }
 
     protected Set<Tag> extractTags(Api api) {
-        Set<Tag> output = new LinkedHashSet<Tag>();
+        Set<Tag> output = new LinkedHashSet<>();
         if(api == null) {
             return output;
         }
@@ -260,7 +260,7 @@ public abstract class AbstractReader {
 
     protected Map<String, Tag> updateTagsForApi(Map<String, Tag> parentTags, Api api) {
         // the value will be used as a tag for 2.0 UNLESS a Tags annotation is present
-        Map<String, Tag> tagsMap = new HashMap<String, Tag>();
+        Map<String, Tag> tagsMap = new HashMap<>();
         for (Tag tag : extractTags(api)) {
             tagsMap.put(tag.getName(), tag);
         }
@@ -319,7 +319,7 @@ public abstract class AbstractReader {
         // whitelist to make sure that the annotation of the parameter is
         // compatible with spring-maven-plugin
 
-        List<Type> validParameterAnnotations = new ArrayList<Type>();
+        List<Type> validParameterAnnotations = new ArrayList<>();
         validParameterAnnotations.add(ModelAttribute.class);
         validParameterAnnotations.add(BeanParam.class);
         validParameterAnnotations.add(InjectParam.class);
@@ -359,7 +359,7 @@ public abstract class AbstractReader {
         }
 
         Iterator<SwaggerExtension> chain = SwaggerExtensions.chain();
-        List<Parameter> parameters = new ArrayList<Parameter>();
+        List<Parameter> parameters = new ArrayList<>();
         Class<?> cls = TypeUtils.getRawType(type, type);
         LOG.debug("Looking for path/query/header/form/cookie params in " + cls);
 
@@ -439,7 +439,7 @@ public abstract class AbstractReader {
 
     protected String[] updateOperationProduces(String[] parentProduces, String[] apiProduces, Operation operation) {
         if (parentProduces != null) {
-            Set<String> both = new LinkedHashSet<String>(Arrays.asList(apiProduces));
+            Set<String> both = new LinkedHashSet<>(Arrays.asList(apiProduces));
             both.addAll(Arrays.asList(parentProduces));
             if (operation.getProduces() != null) {
                 both.addAll(operation.getProduces());
@@ -451,7 +451,7 @@ public abstract class AbstractReader {
 
     protected String[] updateOperationConsumes(String[] parentConsumes, String[] apiConsumes, Operation operation) {
         if (parentConsumes != null) {
-            Set<String> both = new LinkedHashSet<String>(Arrays.asList(apiConsumes));
+            Set<String> both = new LinkedHashSet<>(Arrays.asList(apiConsumes));
             both.addAll(Arrays.asList(parentConsumes));
             if (operation.getConsumes() != null) {
                 both.addAll(operation.getConsumes());

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
@@ -1,32 +1,60 @@
 package com.github.kongchen.swagger.docgen.reader;
 
-import com.github.kongchen.swagger.docgen.jaxrs.BeanParamInjectParamExtention;
-import com.github.kongchen.swagger.docgen.jaxrs.JaxrsParameterExtension;
-import io.swagger.annotations.*;
-import io.swagger.converter.ModelConverters;
-import io.swagger.jaxrs.ext.SwaggerExtension;
-import io.swagger.jaxrs.ext.SwaggerExtensions;
-import io.swagger.jersey.SwaggerJerseyJaxrs;
-import io.swagger.models.*;
-import io.swagger.models.Tag;
-import io.swagger.models.parameters.Parameter;
-import io.swagger.models.properties.Property;
-import io.swagger.models.properties.RefProperty;
-import io.swagger.util.BaseReaderUtils;
-import io.swagger.util.ReflectionUtils;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.HEAD;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.OPTIONS;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
 import org.apache.maven.plugin.logging.Log;
 import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.AnnotationUtils;
 
-import javax.ws.rs.*;
-import javax.ws.rs.HttpMethod;
-import javax.ws.rs.Path;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
-import java.lang.reflect.Type;
-import java.util.*;
+import com.github.kongchen.swagger.docgen.jaxrs.BeanParamInjectParamExtention;
+import com.github.kongchen.swagger.docgen.jaxrs.JaxrsParameterExtension;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
+import io.swagger.annotations.SwaggerDefinition;
+import io.swagger.converter.ModelConverters;
+import io.swagger.jaxrs.ext.SwaggerExtension;
+import io.swagger.jaxrs.ext.SwaggerExtensions;
+import io.swagger.jersey.SwaggerJerseyJaxrs;
+import io.swagger.models.ArrayModel;
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.Operation;
+import io.swagger.models.Response;
+import io.swagger.models.SecurityRequirement;
+import io.swagger.models.Swagger;
+import io.swagger.models.Tag;
+import io.swagger.models.parameters.BodyParameter;
+import io.swagger.models.parameters.Parameter;
+import io.swagger.models.properties.Property;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.util.BaseReaderUtils;
+import io.swagger.util.ReflectionUtils;
 
 public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
     private static final Logger LOGGER = LoggerFactory.getLogger(JaxrsReader.class);
@@ -47,11 +75,11 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
 
     @Override
     protected void updateExtensionChain() {
-    	List<SwaggerExtension> extensions = new ArrayList<SwaggerExtension>();
-    	extensions.add(new BeanParamInjectParamExtention(this));
+        List<SwaggerExtension> extensions = new ArrayList<>();
+        extensions.add(new BeanParamInjectParamExtention(this));
         extensions.add(new SwaggerJerseyJaxrs());
         extensions.add(new JaxrsParameterExtension());
-    	SwaggerExtensions.setExtensions(extensions);
+        SwaggerExtensions.setExtensions(extensions);
     }
 
     @Override
@@ -70,7 +98,8 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
         return read(cls, "", null, false, new String[0], new String[0], new HashMap<String, Tag>(), new ArrayList<Parameter>());
     }
 
-    protected Swagger read(Class<?> cls, String parentPath, String parentMethod, boolean readHidden, String[] parentConsumes, String[] parentProduces, Map<String, Tag> parentTags, List<Parameter> parentParameters) {
+    protected Swagger read(Class<?> cls, String parentPath, String parentMethod, boolean readHidden, String[] parentConsumes,
+            String[] parentProduces, Map<String, Tag> parentTags, List<Parameter> parentParameters) {
         if (swagger == null) {
             swagger = new Swagger();
         }
@@ -121,7 +150,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
             }
             String operationPath = getPath(apiPath, methodPath, parentPathValue);
             if (operationPath != null) {
-                Map<String, String> regexMap = new HashMap<String, String>();
+                Map<String, String> regexMap = new HashMap<>();
                 operationPath = parseOperationPath(operationPath, regexMap);
 
                 String httpMethod = extractOperationMethod(apiOperation, method, SwaggerExtensions.chain());
@@ -161,7 +190,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
 
     private List<Method> getFilteredMethods(Class<?> cls) {
         Method[] methods = cls.getMethods();
-        List<Method> filteredMethods = new ArrayList<Method>();
+        List<Method> filteredMethods = new ArrayList<>();
         for (Method method : methods) {
             if (!method.isBridge()) {
                 filteredMethods.add(method);
@@ -182,7 +211,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
     }
 
     private Map<String, Tag> scanClasspathForTags() {
-        Map<String, Tag> tags = new HashMap<String, Tag>();
+        Map<String, Tag> tags = new HashMap<>();
         for (Class<?> aClass: new Reflections("").getTypesAnnotatedWith(SwaggerDefinition.class)) {
             SwaggerDefinition swaggerDefinition = AnnotationUtils.findAnnotation(aClass, SwaggerDefinition.class);
 
@@ -256,7 +285,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
         ApiOperation apiOperation = AnnotationUtils.findAnnotation(method, ApiOperation.class);
 
         String operationId = getOperationId(method, httpMethod);
-        
+
         String responseContainer = null;
 
         Type responseClassType = null;
@@ -282,7 +311,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
             if (!apiOperation.responseContainer().isEmpty()) {
                 responseContainer = apiOperation.responseContainer();
             }
-            List<SecurityRequirement> securities = new ArrayList<SecurityRequirement>();
+            List<SecurityRequirement> securities = new ArrayList<>();
             for (Authorization auth : apiOperation.authorizations()) {
                 if (!auth.value().isEmpty()) {
                     SecurityRequirement security = new SecurityRequirement();
@@ -403,34 +432,34 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
     }
 
     public static Annotation[][] findParamAnnotations(Method method) {
-		Annotation[][] paramAnnotation = method.getParameterAnnotations();
+        Annotation[][] paramAnnotation = method.getParameterAnnotations();
 
-		Method overriddenMethod = ReflectionUtils.getOverriddenMethod(method);
-		while(overriddenMethod != null) {
-			paramAnnotation = merge(overriddenMethod.getParameterAnnotations(), paramAnnotation);
-			overriddenMethod = ReflectionUtils.getOverriddenMethod(overriddenMethod);
-		}
-		return paramAnnotation;
-	}
+        Method overriddenMethod = ReflectionUtils.getOverriddenMethod(method);
+        while(overriddenMethod != null) {
+            paramAnnotation = merge(overriddenMethod.getParameterAnnotations(), paramAnnotation);
+            overriddenMethod = ReflectionUtils.getOverriddenMethod(overriddenMethod);
+        }
+        return paramAnnotation;
+    }
 
 
     private static Annotation[][] merge(Annotation[][] overriddenMethodParamAnnotation,
-			Annotation[][] currentParamAnnotations) {
-    	Annotation[][] mergedAnnotations = new Annotation[overriddenMethodParamAnnotation.length][];
+            Annotation[][] currentParamAnnotations) {
+        Annotation[][] mergedAnnotations = new Annotation[overriddenMethodParamAnnotation.length][];
 
-    	for(int i=0; i<overriddenMethodParamAnnotation.length; i++) {
-    		mergedAnnotations[i] = merge(overriddenMethodParamAnnotation[i], currentParamAnnotations[i]);
-    	}
-		return mergedAnnotations;
-	}
+        for(int i=0; i<overriddenMethodParamAnnotation.length; i++) {
+            mergedAnnotations[i] = merge(overriddenMethodParamAnnotation[i], currentParamAnnotations[i]);
+        }
+        return mergedAnnotations;
+    }
 
-	private static Annotation[] merge(Annotation[] annotations,
-			Annotation[] annotations2) {
-		List<Annotation> mergedAnnotations = new ArrayList<Annotation>();
-		mergedAnnotations.addAll(Arrays.asList(annotations));
-		mergedAnnotations.addAll(Arrays.asList(annotations2));
-		return mergedAnnotations.toArray(new Annotation[0]);
-	}
+    private static Annotation[] merge(Annotation[] annotations,
+            Annotation[] annotations2) {
+        List<Annotation> mergedAnnotations = new ArrayList<>();
+        mergedAnnotations.addAll(Arrays.asList(annotations));
+        mergedAnnotations.addAll(Arrays.asList(annotations2));
+        return mergedAnnotations.toArray(new Annotation[0]);
+    }
 
 	public String extractOperationMethod(ApiOperation apiOperation, Method method, Iterator<SwaggerExtension> chain) {
         if (apiOperation != null && !apiOperation.httpMethod().isEmpty()) {


### PR DESCRIPTION
If a method consumes an octect-stream the the schema for a byte[] body parameter must be changed.
before
"schema" : { "type" : "array", "items" : { "type" : "string", "format" : "byte" } }

after
"schema" : { "type" : "string", "format" : "byte" }

With this changeset, the created C# Client by swagger-codegen works as expected.