### PR TITLE
WIP: (SpringMVC) Method arguments without annotation are now correctly handled

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,11 @@
             <artifactId>jackson-module-jaxb-annotations</artifactId>
             <version>${jackson.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.leangen.geantyref</groupId>
+            <artifactId>geantyref</artifactId>
+            <version>1.3.6</version>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/src/test/java/com/github/kongchen/swagger/docgen/spring/SpringSwaggerExtensionTest.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/spring/SpringSwaggerExtensionTest.java
@@ -8,14 +8,13 @@ import io.swagger.models.parameters.Parameter;
 import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.maven.plugin.logging.SystemStreamLog;
 import org.springframework.web.bind.annotation.ModelAttribute;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.List;
 
-import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertEquals;
 
 public class SpringSwaggerExtensionTest {
     @Test
@@ -26,8 +25,18 @@ public class SpringSwaggerExtensionTest {
                 Sets.<Type>newHashSet(),
                 Lists.<SwaggerExtension>newArrayList().iterator());
 
-        assertFalse(parameters.isEmpty());
-        Assert.assertEquals(parameters.size(), 2);
+        assertEquals(parameters.size(), 2);
+    }
+
+    @Test
+    public void testExtractParametersNoModelAttributeAnnotation() {
+        List<Parameter> parameters = new SpringSwaggerExtension(new SystemStreamLog()).extractParameters(
+                Lists.newArrayList(),
+                PaginationHelper.class,
+                Sets.<Type>newHashSet(),
+                Lists.<SwaggerExtension>newArrayList().iterator());
+
+        assertEquals(parameters.size(), 2);
     }
 
     private Annotation getTestAnnotation() {


### PR DESCRIPTION
for spring mvc

This implements the behaviour described in the springmvc doc:
"If a method argument is not matched to any of the above, by default it is resolved as an @RequestParam if it is a simple type, as determined by BeanUtils#isSimpleProperty, or as an @ModelAttribute otherwise."
https://docs.spring.io/spring/docs/current/spring-framework-reference/web.html#mvc-ann-arguments

Therefore, no annotations are needed for ModelAttribute and RequestParam.
Also, I fixed the behaviour of the defaultValue. The default was always set to an empty String. Now it is correctly taken from the annotation.
fixes #652


TODO:
* Unit Tests
* Refactoring
* Some more documentation