### PR TITLE
Support @DefaultValue for jax-rs

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/jaxrs/JaxrsParameterExtension.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/jaxrs/JaxrsParameterExtension.java
@@ -1,5 +1,8 @@
 package com.github.kongchen.swagger.docgen.jaxrs;
 
+import com.google.common.base.Strings;
+import com.google.common.collect.ClassToInstanceMap;
+import com.google.common.collect.MutableClassToInstanceMap;
 import io.swagger.converter.ModelConverters;
 import io.swagger.jaxrs.ext.AbstractSwaggerExtension;
 import io.swagger.jaxrs.ext.SwaggerExtension;
@@ -9,10 +12,7 @@ import io.swagger.models.properties.Property;
 import javax.ws.rs.*;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * @author chekong on 15/5/12.
@@ -25,14 +25,10 @@ public class JaxrsParameterExtension extends AbstractSwaggerExtension {
             return new ArrayList<Parameter>();
         }
 
+        ClassToInstanceMap<Annotation> annotationMap = toMap(annotations);
+
         List<Parameter> parameters = new ArrayList<Parameter>();
-        SerializableParameter parameter = null;
-        for (Annotation annotation : annotations) {
-            parameter = getParameter(type, parameter, annotation);
-        }
-        if (parameter != null) {
-            parameters.add(parameter);
-        }
+        parameters.addAll(extractParametersFromAnnotation(type, annotationMap));
 
         if (!parameters.isEmpty()) {
             return parameters;
@@ -40,111 +36,135 @@ public class JaxrsParameterExtension extends AbstractSwaggerExtension {
         return super.extractParameters(annotations, type, typesToSkip, chain);
     }
 
-    private SerializableParameter getParameter(Type type, SerializableParameter parameter, Annotation annotation) {
+    private ClassToInstanceMap<Annotation> toMap(Collection<? extends Annotation> annotations) {
+        ClassToInstanceMap<Annotation> annotationMap = MutableClassToInstanceMap.create();
+        for (Annotation annotation : annotations) {
+            if (annotation == null) {
+                continue;
+            }
+            annotationMap.put(annotation.annotationType(), annotation);
+        }
+
+        return annotationMap;
+    }
+
+    private List<Parameter> extractParametersFromAnnotation(Type type, ClassToInstanceMap<Annotation> annotations) {
         String defaultValue = "";
-        if (annotation instanceof DefaultValue) {
-            DefaultValue defaultValueAnnotation = (DefaultValue) annotation;
+        if (annotations.containsKey(DefaultValue.class)) {
+            DefaultValue defaultValueAnnotation = annotations.getInstance(DefaultValue.class);
             defaultValue = defaultValueAnnotation.value();
         }
 
-        if (annotation instanceof QueryParam) {
-            QueryParam param = (QueryParam) annotation;
-            QueryParameter queryParameter = new QueryParameter().name(param.value());
-
-            if (!defaultValue.isEmpty()) {
-                queryParameter.setDefaultValue(defaultValue);
-            }
-            Property schema = ModelConverters.getInstance().readAsProperty(type);
-            if (schema != null) {
-                queryParameter.setProperty(schema);
-            }
-
-            String parameterType = queryParameter.getType();
-
-            if (parameterType == null || parameterType.equals("ref")) {
-                queryParameter.setType("string");
-            }
-            parameter = queryParameter;
-        } else if (annotation instanceof PathParam) {
-            PathParam param = (PathParam) annotation;
-            PathParameter pathParameter = new PathParameter().name(param.value());
-            if (!defaultValue.isEmpty()) {
-                pathParameter.setDefaultValue(defaultValue);
-            }
-            Property schema = ModelConverters.getInstance().readAsProperty(type);
-            if (schema != null) {
-                pathParameter.setProperty(schema);
-            }
-
-            String parameterType = pathParameter.getType();
-            if (parameterType == null || parameterType.equals("ref")) {
-                pathParameter.setType("string");
-            }
-            parameter = pathParameter;
-        } else if (annotation instanceof HeaderParam) {
-            HeaderParam param = (HeaderParam) annotation;
-            HeaderParameter headerParameter = new HeaderParameter().name(param.value());
-            headerParameter.setDefaultValue(defaultValue);
-            Property schema = ModelConverters.getInstance().readAsProperty(type);
-            if (schema != null) {
-                headerParameter.setProperty(schema);
-            }
-
-            String parameterType = headerParameter.getType();
-            if (parameterType == null || parameterType.equals("ref") || parameterType.equals("array")) {
-                headerParameter.setType("string");
-            }
-            parameter = headerParameter;
-        } else if (annotation instanceof CookieParam) {
-            CookieParam param = (CookieParam) annotation;
-            CookieParameter cookieParameter = new CookieParameter().name(param.value());
-            if (!defaultValue.isEmpty()) {
-                cookieParameter.setDefaultValue(defaultValue);
-            }
-            Property schema = ModelConverters.getInstance().readAsProperty(type);
-            if (schema != null) {
-                cookieParameter.setProperty(schema);
-            }
-
-            String parameterType = cookieParameter.getType();
-            if (parameterType == null || parameterType.equals("ref") || parameterType.equals("array")) {
-                cookieParameter.setType("string");
-            }
-            parameter = cookieParameter;
-        } else if (annotation instanceof FormParam) {
-            FormParam param = (FormParam) annotation;
-            FormParameter formParameter = new FormParameter().name(param.value());
-            if (!defaultValue.isEmpty()) {
-                formParameter.setDefaultValue(defaultValue);
-            }
-            Property schema = ModelConverters.getInstance().readAsProperty(type);
-            if (schema != null) {
-                formParameter.setProperty(schema);
-            }
-
-            String parameterType = formParameter.getType();
-            if (parameterType == null || parameterType.equals("ref") || parameterType.equals("array")) {
-                formParameter.setType("string");
-            }
-            parameter = formParameter;
+        List<Parameter> parameters = new ArrayList<>();
+        if (annotations.containsKey(QueryParam.class)) {
+            QueryParam param = annotations.getInstance(QueryParam.class);
+            QueryParameter queryParameter = extractQueryParam(type, defaultValue, param);
+            parameters.add(queryParameter);
+        } else if (annotations.containsKey(PathParam.class)) {
+            PathParam param = annotations.getInstance(PathParam.class);
+            PathParameter pathParameter = extractPathParam(type, defaultValue, param);
+            parameters.add(pathParameter);
+        } else if (annotations.containsKey(HeaderParam.class)) {
+            HeaderParam param = annotations.getInstance(HeaderParam.class);
+            HeaderParameter headerParameter = extractHeaderParam(type, defaultValue, param);
+            parameters.add(headerParameter);
+        } else if (annotations.containsKey(CookieParam.class)) {
+            CookieParam param = annotations.getInstance(CookieParam.class);
+            CookieParameter cookieParameter = extractCookieParameter(type, defaultValue, param);
+            parameters.add(cookieParameter);
+        } else if (annotations.containsKey(FormParam.class)) {
+            FormParam param = annotations.getInstance(FormParam.class);
+            FormParameter formParameter = extractFormParameter(type, defaultValue, param);
+            parameters.add(formParameter);
         }
 
-        //                //fix parameter type issue, try to access parameter's type
-//                try {
-//                    Field t = parameter.getClass().getDeclaredField("type");
-//                    t.setAccessible(true);
-//                    Object tval = t.get(parameter);
-//                    if (tval.equals("ref")) {
-//                        //fix to string
-//                        t.set(parameter, "string");
-//                    }
-//                    t.setAccessible(false);
-//                } catch (NoSuchFieldException e) {
-//                    //ignore
-//                } catch (IllegalAccessException e) {
-//                    //ignore
-//                }
-//
-        return parameter;
+        return parameters;
+    }
+
+    private QueryParameter extractQueryParam(Type type, String defaultValue, QueryParam param) {
+        QueryParameter queryParameter = new QueryParameter().name(param.value());
+
+        if (!Strings.isNullOrEmpty(defaultValue)) {
+            queryParameter.setDefaultValue(defaultValue);
+        }
+        Property schema = ModelConverters.getInstance().readAsProperty(type);
+        if (schema != null) {
+            queryParameter.setProperty(schema);
+        }
+
+        String parameterType = queryParameter.getType();
+
+        if (parameterType == null || parameterType.equals("ref")) {
+            queryParameter.setType("string");
+        }
+        return queryParameter;
+    }
+
+    private PathParameter extractPathParam(Type type, String defaultValue, PathParam param) {
+        PathParameter pathParameter = new PathParameter().name(param.value());
+        if (!Strings.isNullOrEmpty(defaultValue)) {
+            pathParameter.setDefaultValue(defaultValue);
+        }
+        Property schema = ModelConverters.getInstance().readAsProperty(type);
+        if (schema != null) {
+            pathParameter.setProperty(schema);
+        }
+
+        String parameterType = pathParameter.getType();
+        if (parameterType == null || parameterType.equals("ref")) {
+            pathParameter.setType("string");
+        }
+        return pathParameter;
+    }
+
+    private HeaderParameter extractHeaderParam(Type type, String defaultValue, HeaderParam param) {
+        HeaderParameter headerParameter = new HeaderParameter().name(param.value());
+        if (!Strings.isNullOrEmpty(defaultValue)) {
+            headerParameter.setDefaultValue(defaultValue);
+        }
+        Property schema = ModelConverters.getInstance().readAsProperty(type);
+        if (schema != null) {
+            headerParameter.setProperty(schema);
+        }
+
+        String parameterType = headerParameter.getType();
+        if (parameterType == null || parameterType.equals("ref") || parameterType.equals("array")) {
+            headerParameter.setType("string");
+        }
+        return headerParameter;
+    }
+
+    private CookieParameter extractCookieParameter(Type type, String defaultValue, CookieParam param) {
+        CookieParameter cookieParameter = new CookieParameter().name(param.value());
+        if (!Strings.isNullOrEmpty(defaultValue)) {
+            cookieParameter.setDefaultValue(defaultValue);
+        }
+        Property schema = ModelConverters.getInstance().readAsProperty(type);
+        if (schema != null) {
+            cookieParameter.setProperty(schema);
+        }
+
+        String parameterType = cookieParameter.getType();
+        if (parameterType == null || parameterType.equals("ref") || parameterType.equals("array")) {
+            cookieParameter.setType("string");
+        }
+        return cookieParameter;
+    }
+
+    private FormParameter extractFormParameter(Type type, String defaultValue, FormParam param) {
+        FormParameter formParameter = new FormParameter().name(param.value());
+        if (!Strings.isNullOrEmpty(defaultValue)) {
+            formParameter.setDefaultValue(defaultValue);
+        }
+        Property schema = ModelConverters.getInstance().readAsProperty(type);
+        if (schema != null) {
+            formParameter.setProperty(schema);
+        }
+
+        String parameterType = formParameter.getType();
+        if (parameterType == null || parameterType.equals("ref") || parameterType.equals("array")) {
+            formParameter.setType("string");
+        }
+        return formParameter;
     }
 }

--- a/src/test/java/com/github/kongchen/swagger/docgen/jaxrs/JaxrsParameterExtensionTest.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/jaxrs/JaxrsParameterExtensionTest.java
@@ -3,10 +3,12 @@ package com.github.kongchen.swagger.docgen.jaxrs;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import io.swagger.jaxrs.ext.SwaggerExtension;
+import io.swagger.models.parameters.AbstractSerializableParameter;
 import io.swagger.models.parameters.Parameter;
 import org.apache.commons.lang3.reflect.MethodUtils;
 import org.testng.annotations.Test;
 
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.QueryParam;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
@@ -19,7 +21,7 @@ public class JaxrsParameterExtensionTest {
     @Test
     public void testExtractParametersReturnsRetrievedParameters() {
         List<Parameter> parameters = new JaxrsParameterExtension().extractParameters(
-                Lists.newArrayList(getTestAnnotation()),
+                Lists.newArrayList(getTestAnnotation("get", QueryParam.class)),
                 String.class,
                 Sets.<Type>newHashSet(),
                 Lists.<SwaggerExtension>newArrayList().iterator());
@@ -28,8 +30,27 @@ public class JaxrsParameterExtensionTest {
         assertEquals(parameters.size(), 1);
     }
 
-    private Annotation getTestAnnotation() {
-        return MethodUtils.getMethodsWithAnnotation(SomeResource.class, QueryParam.class)[0].getAnnotation(QueryParam.class);
+
+    private Annotation getTestAnnotation(String name, Class<? extends Annotation> wantedAnnotation) {
+        return MethodUtils.getMatchingMethod(SomeResource.class, name, String.class).getAnnotation(wantedAnnotation);
+    }
+
+    @Test
+    public void testParameterDefaultValue() {
+        List<Parameter> parameters = new JaxrsParameterExtension().extractParameters(
+                Lists.newArrayList(
+                        getTestAnnotation("getWithDefault", QueryParam.class),
+                        getTestAnnotation("getWithDefault", DefaultValue.class)
+                ),
+                String.class,
+                Sets.<Type>newHashSet(),
+                Lists.<SwaggerExtension>newArrayList().iterator());
+
+        assertFalse(parameters.isEmpty());
+        assertEquals(parameters.size(), 1);
+
+        Parameter extracted = parameters.get(0);
+        assertEquals(((AbstractSerializableParameter)extracted).getDefaultValue(), "en-US");
     }
 
     private static class SomeResource {
@@ -37,6 +58,12 @@ public class JaxrsParameterExtensionTest {
         public void get(String lang) {
             // no implementation needed. Method is only for the test cases, so that the annotation QueryParam
             // can easily be retrieved and used
+        }
+
+        @QueryParam("lang")
+        @DefaultValue("en-US")
+        public void getWithDefault(String lang) {
+            // Needed for testing default values with jaxrs
         }
     }
 }


### PR DESCRIPTION
Correct the behavior of the DefaultValue annotation. It is now being applied to the Parameters.

This changes the extraction of the parameters for jaxrs, so that all of annotations are available at once. A contextual extraction is therefore now possible, allowing Annotations to access values of other annotations

This mostly matches how currently the SpringSwaggerExtension is implemented.

closes #591