### PR TITLE
Update to swagger-core 1.5.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 
         <!-- Dependency versions -->
         <maven.version>2.2.1</maven.version>
-        <swagger.version>1.5.18</swagger.version>
+        <swagger.version>1.5.21</swagger.version>
         <jackson.version>2.8.9</jackson.version>
         <log4j.version>1.2.16</log4j.version>
         <handlebars.version>1.3.2</handlebars.version>

--- a/src/main/java/com/github/kongchen/swagger/docgen/AbstractDocumentSource.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/AbstractDocumentSource.java
@@ -1,6 +1,5 @@
 package com.github.kongchen.swagger.docgen;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -63,7 +62,7 @@ public abstract class AbstractDocumentSource {
     private final String swaggerPath;
     private final String modelSubstitute;
     private final boolean jsonExampleValues;
-    private ObjectMapper mapper = new ObjectMapper();
+    private ObjectMapper mapper = Json.mapper();
     private boolean isSorted = false;
     protected String encoding = "UTF-8";
 
@@ -169,7 +168,8 @@ public abstract class AbstractDocumentSource {
 
     public void toSwaggerDocuments(String uiDocBasePath, String outputFormats, String fileName, String encoding) throws GenerateException {
         mapper.configure(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS, false);
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+        mapper = mapper.copy();
 
         if (jsonExampleValues) {
             mapper.addMixInAnnotations(Property.class, PropertyExampleMixIn.class);

--- a/src/main/java/com/github/kongchen/swagger/docgen/PropertyExampleMixIn.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/PropertyExampleMixIn.java
@@ -5,5 +5,5 @@ import com.fasterxml.jackson.annotation.JsonRawValue;
 abstract class PropertyExampleMixIn {
     PropertyExampleMixIn() { }
     
-    @JsonRawValue abstract String getExample();
+    @JsonRawValue abstract Object getExample();
 }

--- a/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/SecurityDefinition.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/SecurityDefinition.java
@@ -7,6 +7,7 @@ import io.swagger.models.auth.ApiKeyAuthDefinition;
 import io.swagger.models.auth.BasicAuthDefinition;
 import io.swagger.models.auth.OAuth2Definition;
 import io.swagger.models.auth.SecuritySchemeDefinition;
+import io.swagger.util.Json;
 import org.apache.commons.lang3.reflect.FieldUtils;
 
 import java.io.FileInputStream;
@@ -28,6 +29,8 @@ public class SecurityDefinition {
     private String json;
     private String jsonPath;
 
+    private ObjectMapper mapper = Json.mapper();
+
     public Map<String, SecuritySchemeDefinition> generateSecuritySchemeDefinitions() throws GenerateException {
         Map<String, SecuritySchemeDefinition> map = new HashMap<String, SecuritySchemeDefinition>();
 
@@ -35,7 +38,7 @@ public class SecurityDefinition {
         if (json != null || jsonPath != null) {
             securityDefinitions = loadSecurityDefintionsFromJsonFile();
         } else {
-            JsonNode tree = new ObjectMapper().valueToTree(this);
+            JsonNode tree = mapper.valueToTree(this);
             securityDefinitions.put(tree.get("name").asText(), tree);
         }
 
@@ -81,7 +84,7 @@ public class SecurityDefinition {
 
         try {
             InputStream jsonStream = json != null ? this.getClass().getResourceAsStream(json) : new FileInputStream(jsonPath);
-            JsonNode tree = new ObjectMapper().readTree(jsonStream);
+            JsonNode tree = mapper.readTree(jsonStream);
             Iterator<Map.Entry<String, JsonNode>> fields = tree.fields();
             while(fields.hasNext()) {
                 Map.Entry<String, JsonNode> field = fields.next();
@@ -98,7 +101,6 @@ public class SecurityDefinition {
 
     private SecuritySchemeDefinition getSecuritySchemeDefinitionByType(String type, JsonNode node) throws GenerateException {
         try {
-            ObjectMapper mapper = new ObjectMapper();
             SecuritySchemeDefinition def = null;
             if (type.equals(new OAuth2Definition().getType())) {
                 def = new OAuth2Definition();

--- a/src/test/java/com/github/kongchen/smp/integration/JaxrsEnhancedOperationIdTest.java
+++ b/src/test/java/com/github/kongchen/smp/integration/JaxrsEnhancedOperationIdTest.java
@@ -1,30 +1,29 @@
 package com.github.kongchen.smp.integration;
 
-import static net.javacrumbs.jsonunit.JsonAssert.assertJsonEquals;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.kongchen.swagger.docgen.mavenplugin.ApiDocumentMojo;
+import io.swagger.jaxrs.ext.SwaggerExtension;
+import io.swagger.jaxrs.ext.SwaggerExtensions;
+import io.swagger.util.Json;
+import net.javacrumbs.jsonunit.core.Configuration;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.kongchen.swagger.docgen.mavenplugin.ApiDocumentMojo;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
-import io.swagger.jaxrs.ext.SwaggerExtension;
-import io.swagger.jaxrs.ext.SwaggerExtensions;
-import net.javacrumbs.jsonunit.core.Configuration;
+import static net.javacrumbs.jsonunit.JsonAssert.assertJsonEquals;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
 
 public class JaxrsEnhancedOperationIdTest extends AbstractMojoTestCase {
     private File swaggerOutputDir = new File(getBasedir(), "generated/swagger-ui-enhanced-operation-id");
     private ApiDocumentMojo mojo;
-    private ObjectMapper mapper = new ObjectMapper();
+    private ObjectMapper mapper = Json.mapper();
     private List<SwaggerExtension> extensions;
 
     @Override

--- a/src/test/java/com/github/kongchen/smp/integration/SpringMvcEnhancedOperationIdTest.java
+++ b/src/test/java/com/github/kongchen/smp/integration/SpringMvcEnhancedOperationIdTest.java
@@ -1,13 +1,12 @@
 package com.github.kongchen.smp.integration;
 
-import static net.javacrumbs.jsonunit.JsonAssert.assertJsonEquals;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.kongchen.swagger.docgen.mavenplugin.ApiDocumentMojo;
+import io.swagger.jaxrs.ext.SwaggerExtension;
+import io.swagger.jaxrs.ext.SwaggerExtensions;
+import io.swagger.util.Json;
+import net.javacrumbs.jsonunit.core.Configuration;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -16,13 +15,13 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.kongchen.swagger.docgen.mavenplugin.ApiDocumentMojo;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
-import io.swagger.jaxrs.ext.SwaggerExtension;
-import io.swagger.jaxrs.ext.SwaggerExtensions;
-import net.javacrumbs.jsonunit.core.Configuration;
+import static net.javacrumbs.jsonunit.JsonAssert.assertJsonEquals;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
 
 public class SpringMvcEnhancedOperationIdTest extends AbstractMojoTestCase {
     private File swaggerOutputDir = new File(getBasedir(), "generated/swagger-ui-spring-enhanced-operation-id");
@@ -55,7 +54,7 @@ public class SpringMvcEnhancedOperationIdTest extends AbstractMojoTestCase {
     @Test
     public void testAssertGeneratedSwaggerSpecJson() throws MojoExecutionException, MojoFailureException, IOException {
         mojo.execute();
-        ObjectMapper mapper = new ObjectMapper();
+        ObjectMapper mapper = Json.mapper();
         JsonNode actualJson = mapper.readTree(new File(swaggerOutputDir, "swagger.json"));
         JsonNode expectJson = mapper.readTree(this.getClass().getResourceAsStream("/expectedOutput/swagger-spring-enhanced-operation-id.json"));
 

--- a/src/test/java/com/github/kongchen/smp/integration/SpringMvcSkipInheritedTest.java
+++ b/src/test/java/com/github/kongchen/smp/integration/SpringMvcSkipInheritedTest.java
@@ -1,13 +1,12 @@
 package com.github.kongchen.smp.integration;
 
-import static net.javacrumbs.jsonunit.JsonAssert.assertJsonEquals;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.kongchen.swagger.docgen.mavenplugin.ApiDocumentMojo;
+import io.swagger.jaxrs.ext.SwaggerExtension;
+import io.swagger.jaxrs.ext.SwaggerExtensions;
+import io.swagger.util.Json;
+import net.javacrumbs.jsonunit.core.Configuration;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -16,13 +15,13 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.kongchen.swagger.docgen.mavenplugin.ApiDocumentMojo;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
-import io.swagger.jaxrs.ext.SwaggerExtension;
-import io.swagger.jaxrs.ext.SwaggerExtensions;
-import net.javacrumbs.jsonunit.core.Configuration;
+import static net.javacrumbs.jsonunit.JsonAssert.assertJsonEquals;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
 
 public class SpringMvcSkipInheritedTest extends AbstractMojoTestCase {
     private File swaggerOutputDir = new File(getBasedir(), "generated/swagger-ui-spring-skip-inherited");
@@ -57,7 +56,7 @@ public class SpringMvcSkipInheritedTest extends AbstractMojoTestCase {
     @Test
     public void testAssertGeneratedSwaggerSpecJson() throws MojoExecutionException, MojoFailureException, IOException {
         mojo.execute();
-        ObjectMapper mapper = new ObjectMapper();
+        ObjectMapper mapper = Json.mapper();
         JsonNode actualJson = mapper.readTree(new File(swaggerOutputDir, "swagger.json"));
         JsonNode expectJson = mapper.readTree(this.getClass().getResourceAsStream("/expectedOutput/swagger-spring-skip-inherited.json"));
 

--- a/src/test/java/com/github/kongchen/smp/integration/SpringMvcTest.java
+++ b/src/test/java/com/github/kongchen/smp/integration/SpringMvcTest.java
@@ -8,6 +8,7 @@ import com.google.common.base.CharMatcher;
 import com.google.common.io.Files;
 import io.swagger.jaxrs.ext.SwaggerExtension;
 import io.swagger.jaxrs.ext.SwaggerExtensions;
+import io.swagger.util.Json;
 import net.javacrumbs.jsonunit.core.Configuration;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -158,7 +159,7 @@ public class SpringMvcTest extends AbstractMojoTestCase {
         mojo.execute();
 
         // check generated swagger json file
-        ObjectMapper mapper = new ObjectMapper();
+        ObjectMapper mapper = Json.mapper();
         JsonNode actualJson = mapper.readTree(new File(swaggerOutputDir, "swagger.json"));
         JsonNode expectJson = mapper.readTree(this.getClass().getResourceAsStream("/options/jsonExampleValues/expected/swagger-spring.json"));
 
@@ -213,7 +214,7 @@ public class SpringMvcTest extends AbstractMojoTestCase {
 
     private void assertGeneratedSwaggerSpecJson(String description) throws MojoExecutionException, MojoFailureException, IOException {
         mojo.execute();
-        ObjectMapper mapper = new ObjectMapper();
+        ObjectMapper mapper = Json.mapper();
         JsonNode actualJson = mapper.readTree(new File(swaggerOutputDir, "swagger.json"));
         JsonNode expectJson = mapper.readTree(this.getClass().getResourceAsStream("/expectedOutput/swagger-spring.json"));
 
@@ -232,7 +233,7 @@ public class SpringMvcTest extends AbstractMojoTestCase {
         String actualYaml = yaml.dump(yaml.load(FileUtils.readFileToString(new File(swaggerOutputDir, "swagger.yaml"))));
         String expectYaml = yaml.dump(yaml.load(this.getClass().getResourceAsStream("/expectedOutput/swagger-spring.yaml")));
 
-        ObjectMapper mapper = new ObjectMapper();
+        ObjectMapper mapper = Json.mapper();
         JsonNode actualJson = mapper.readTree(YamlToJson(actualYaml));
         JsonNode expectJson = mapper.readTree(YamlToJson(expectYaml));
 

--- a/src/test/java/com/github/kongchen/smp/integration/SpringMvcTest.java
+++ b/src/test/java/com/github/kongchen/smp/integration/SpringMvcTest.java
@@ -165,8 +165,7 @@ public class SpringMvcTest extends AbstractMojoTestCase {
         JsonNode actualUserNode = actualJson.path("definitions").path("User");
         JsonNode expectUserNode = expectJson.path("definitions").path("User");
 
-        // Cannot test full node equality since tags order is not guaranteed in generated json
-        Assert.assertEquals(actualUserNode, expectUserNode);
+        assertJsonEquals(expectUserNode, actualUserNode, Configuration.empty().when(IGNORING_ARRAY_ORDER));
     }
 
     @Test

--- a/src/test/java/com/github/kongchen/smp/integration/StringWrapperModelTest.java
+++ b/src/test/java/com/github/kongchen/smp/integration/StringWrapperModelTest.java
@@ -3,32 +3,23 @@ package com.github.kongchen.smp.integration;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.kongchen.swagger.docgen.mavenplugin.ApiDocumentMojo;
-import com.github.kongchen.swagger.docgen.mavenplugin.ApiSource;
-import com.google.common.base.CharMatcher;
-import com.google.common.io.Files;
 import io.swagger.jaxrs.ext.SwaggerExtension;
 import io.swagger.jaxrs.ext.SwaggerExtensions;
+import io.swagger.util.Json;
 import net.javacrumbs.jsonunit.core.Configuration;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
-import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import org.yaml.snakeyaml.DumperOptions;
-import org.yaml.snakeyaml.Yaml;
 
-import java.io.*;
-import java.nio.charset.Charset;
+import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 
-import static com.github.kongchen.smp.integration.utils.TestUtils.*;
 import static net.javacrumbs.jsonunit.JsonAssert.assertJsonEquals;
 import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
 
@@ -66,7 +57,7 @@ public class StringWrapperModelTest extends AbstractMojoTestCase {
     @Test
     public void testAssertGeneratedSwaggerSpecJson() throws MojoExecutionException, MojoFailureException, IOException {
         mojo.execute();
-        ObjectMapper mapper = new ObjectMapper();
+        ObjectMapper mapper = Json.mapper();
         JsonNode actualJson = mapper.readTree(new File(swaggerOutputDir, "swagger.json"));
         JsonNode expectJson = mapper.readTree(this.getClass().getResourceAsStream("/expectedOutput/swagger-spring-string-wrapper-model.json"));
 

--- a/src/test/java/com/github/kongchen/smp/integration/SwaggerMavenPluginTest.java
+++ b/src/test/java/com/github/kongchen/smp/integration/SwaggerMavenPluginTest.java
@@ -8,9 +8,9 @@ import com.github.kongchen.smp.integration.utils.PetIdToStringModelConverter;
 import com.github.kongchen.swagger.docgen.mavenplugin.ApiDocumentMojo;
 import com.github.kongchen.swagger.docgen.mavenplugin.ApiSource;
 import com.google.common.collect.ImmutableList;
-
 import io.swagger.jaxrs.ext.SwaggerExtension;
 import io.swagger.jaxrs.ext.SwaggerExtensions;
+import io.swagger.util.Json;
 import net.javacrumbs.jsonunit.core.Configuration;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -23,23 +23,15 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.yaml.snakeyaml.Yaml;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-
-import static com.github.kongchen.smp.integration.utils.TestUtils.YamlToJson;
-import static com.github.kongchen.smp.integration.utils.TestUtils.changeDescription;
-import static com.github.kongchen.smp.integration.utils.TestUtils.createTempDirPath;
-import static com.github.kongchen.smp.integration.utils.TestUtils.setCustomReader;
-import io.swagger.util.Json;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import static com.github.kongchen.smp.integration.utils.TestUtils.*;
 import static net.javacrumbs.jsonunit.JsonAssert.assertJsonEquals;
 import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
 
@@ -51,7 +43,7 @@ public class SwaggerMavenPluginTest extends AbstractMojoTestCase {
     private File swaggerOutputDir = new File(getBasedir(), "generated/swagger-ui");
     private File docOutput = new File(getBasedir(), "generated/document.html");
     private ApiDocumentMojo mojo;
-    private ObjectMapper mapper = new ObjectMapper();
+    private ObjectMapper mapper = Json.mapper();
     private List<SwaggerExtension> extensions;
 
     @Override

--- a/src/test/java/com/github/kongchen/smp/integration/SwaggerReaderTest.java
+++ b/src/test/java/com/github/kongchen/smp/integration/SwaggerReaderTest.java
@@ -3,6 +3,7 @@ package com.github.kongchen.smp.integration;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.kongchen.swagger.docgen.mavenplugin.ApiDocumentMojo;
+import io.swagger.util.Json;
 import net.javacrumbs.jsonunit.core.Configuration;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
@@ -23,7 +24,7 @@ import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
 public class SwaggerReaderTest extends AbstractMojoTestCase {
     private File swaggerOutputDir = new File(getBasedir(), "generated/swagger-ui");
     private ApiDocumentMojo mojo;
-    private ObjectMapper mapper = new ObjectMapper();
+    private ObjectMapper mapper = Json.mapper();
 
     @Override
 	@BeforeMethod

--- a/src/test/java/com/github/kongchen/smp/integration/utils/PetIdToStringModelConverter.java
+++ b/src/test/java/com/github/kongchen/smp/integration/utils/PetIdToStringModelConverter.java
@@ -1,10 +1,10 @@
 package com.github.kongchen.smp.integration.utils;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.converter.ModelConverter;
 import io.swagger.converter.ModelConverterContext;
 import io.swagger.jackson.AbstractModelConverter;
 import io.swagger.models.properties.Property;
+import io.swagger.util.Json;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
@@ -16,7 +16,7 @@ import java.util.Iterator;
 public class PetIdToStringModelConverter extends AbstractModelConverter {
 
     public PetIdToStringModelConverter() {
-        super(new ObjectMapper());
+        super(Json.mapper().copy());
     }
 
     @Override

--- a/src/test/java/com/github/kongchen/swagger/docgen/reader/JaxrsReaderTest.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/reader/JaxrsReaderTest.java
@@ -13,6 +13,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import io.swagger.util.Json;
 import org.apache.maven.plugin.logging.Log;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -152,8 +153,7 @@ public class JaxrsReaderTest {
             assertTrue(parameter instanceof RefParameter);
         }
 
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        ObjectMapper mapper = Json.mapper();
         ObjectWriter jsonWriter = mapper.writer(new DefaultPrettyPrinter());
         String json = jsonWriter.writeValueAsString(result);
         JsonNode expectJson = mapper.readTree(this.getClass().getResourceAsStream("/expectedOutput/swagger-common-parameters.json"));

--- a/src/test/java/com/github/kongchen/swagger/docgen/reader/ModelModifierTest.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/reader/ModelModifierTest.java
@@ -1,9 +1,16 @@
 package com.github.kongchen.swagger.docgen.reader;
 
 import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.SimpleType;
-
+import io.swagger.annotations.ApiModelProperty;
+import io.swagger.converter.ModelConverter;
+import io.swagger.converter.ModelConverterContext;
+import io.swagger.converter.ModelConverterContextImpl;
+import io.swagger.models.ArrayModel;
+import io.swagger.models.Model;
+import io.swagger.models.properties.Property;
+import io.swagger.models.properties.StringProperty;
+import io.swagger.util.Json;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -14,15 +21,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import io.swagger.annotations.ApiModelProperty;
-import io.swagger.converter.ModelConverter;
-import io.swagger.converter.ModelConverterContext;
-import io.swagger.converter.ModelConverterContextImpl;
-import io.swagger.models.ArrayModel;
-import io.swagger.models.Model;
-import io.swagger.models.properties.Property;
-import io.swagger.models.properties.StringProperty;
-
 /**
  * Created by mkosiorek on 25.04.17.
  */
@@ -30,7 +28,7 @@ public class ModelModifierTest {
 
     @Test
     public void testProcessFieldInParentClass() throws Exception {
-        ModelModifier modelModifier =  new ModelModifier(new ObjectMapper());
+        ModelModifier modelModifier =  new ModelModifier(Json.mapper());
         modelModifier.setApiModelPropertyAccessExclusions(Arrays.asList("public"));
 
         JavaType type = SimpleType.constructUnsafe(B.class);

--- a/src/test/resources/expectedOutput/swagger-swaggerreader.json
+++ b/src/test/resources/expectedOutput/swagger-swaggerreader.json
@@ -737,7 +737,7 @@
         "tags" : [ "pet" ],
         "summary" : "Find pet(s) by ID",
         "description" : "This is a contrived example of a path segment containing multiple path parameters, separated by a character which may be present in the path parameter template. You may think that it returns a range of pets from startId to endId, inclusive, but it doesn't.",
-        "operationId" : "getPetsById",
+        "operationId" : "getPetsById_1",
         "produces" : [ "application/json", "application/xml" ],
         "parameters" : [ {
           "name" : "startId",

--- a/src/test/resources/expectedOutput/swagger-swaggerreader.yaml
+++ b/src/test/resources/expectedOutput/swagger-swaggerreader.yaml
@@ -661,7 +661,7 @@ paths:
         \ path parameters, separated by a character which may be present in the path\
         \ parameter template. You may think that it returns a range of pets from startId\
         \ to endId, inclusive, but it doesn't."
-      operationId: "getPetsById"
+      operationId: "getPetsById_1"
       produces:
       - "application/json"
       - "application/xml"


### PR DESCRIPTION
Needed for picking up bug fix swagger-api/swagger-core#2707, and to also later on be able to support the new accessmode property.

Had to make some changes to the objectmapper for swagger-api/swagger-parser#772.
Also, needed to adjust the names of some operations in the expected outputs for swagger-api/swagger-core#2671.

closes #654
related to #633
