### PR TITLE
Fix potential InputStream resource leak

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/AbstractDocumentSource.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/AbstractDocumentSource.java
@@ -83,10 +83,8 @@ public abstract class AbstractDocumentSource {
 
         // read description from file
         if (apiSource.getDescriptionFile() != null) {
-            try {
-                InputStream is = new FileInputStream(apiSource.getDescriptionFile());
+            try (InputStream is = new FileInputStream(apiSource.getDescriptionFile())) {
                 apiSource.getInfo().setDescription(IOUtils.toString(is));
-                is.close();
             } catch (IOException e) {
                 throw new MojoFailureException(e.getMessage(), e);
             }

--- a/src/main/java/com/github/kongchen/swagger/docgen/AbstractDocumentSource.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/AbstractDocumentSource.java
@@ -83,10 +83,14 @@ public abstract class AbstractDocumentSource {
 
         // read description from file
         if (apiSource.getDescriptionFile() != null) {
-            try (InputStream is = new FileInputStream(apiSource.getDescriptionFile())) {
+            InputStream is = null;
+            try {
+                is = new FileInputStream(apiSource.getDescriptionFile());
                 apiSource.getInfo().setDescription(IOUtils.toString(is));
             } catch (IOException e) {
                 throw new MojoFailureException(e.getMessage(), e);
+            } finally {
+                IOUtils.closeQuietly(is);
             }
         }
 

--- a/src/test/java/com/github/kongchen/swagger/docgen/AbstractDocumentSourceTest.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/AbstractDocumentSourceTest.java
@@ -3,21 +3,26 @@ package com.github.kongchen.swagger.docgen;
 import com.github.kongchen.swagger.docgen.mavenplugin.ApiSource;
 import com.github.kongchen.swagger.docgen.reader.ClassSwaggerReader;
 import io.swagger.models.ExternalDocs;
+import io.swagger.models.Info;
 import io.swagger.models.Path;
 import io.swagger.models.Swagger;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
 
 public class AbstractDocumentSourceTest {
     @Mock
@@ -58,7 +63,7 @@ public class AbstractDocumentSourceTest {
     @Test
     public void testExternalDocsGetAdded() throws MojoFailureException {
         // arrange
-        Mockito.when(apiSource.getExternalDocs()).thenReturn(new ExternalDocs("Example external docs", "https://example.com/docs"));
+        when(apiSource.getExternalDocs()).thenReturn(new ExternalDocs("Example external docs", "https://example.com/docs"));
 
         // act
         AbstractDocumentSource externalDocsSource = new AbstractDocumentSource(log, apiSource) {
@@ -72,5 +77,27 @@ public class AbstractDocumentSourceTest {
         assertThat(externalDocsSource.swagger.getExternalDocs(), notNullValue());
         assertThat(externalDocsSource.swagger.getExternalDocs().getDescription(), equalTo("Example external docs"));
         assertThat(externalDocsSource.swagger.getExternalDocs().getUrl(), equalTo("https://example.com/docs"));
+    }
+
+    @Test
+    public void testAddDescriptionFile() throws URISyntaxException, MojoFailureException {
+
+        // arrange
+        URI fileUri = this.getClass().getResource("descriptionFile.txt").toURI();
+        File descriptionFile = new File(fileUri);
+
+        when(apiSource.getDescriptionFile()).thenReturn(descriptionFile);
+        when(apiSource.getInfo()).thenReturn(new Info());
+
+        // act
+        AbstractDocumentSource externalDocsSource = new AbstractDocumentSource(log, apiSource) {
+            @Override
+            protected ClassSwaggerReader resolveApiReader() throws GenerateException {
+                return null;
+            }
+        };
+
+        // assert
+        assertThat(externalDocsSource.swagger.getInfo().getDescription(), is("Description file content\n"));
     }
 }

--- a/src/test/java/com/github/kongchen/swagger/docgen/AbstractDocumentSourceTest.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/AbstractDocumentSourceTest.java
@@ -14,7 +14,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;

--- a/src/test/resources/com/github/kongchen/swagger/docgen/descriptionFile.txt
+++ b/src/test/resources/com/github/kongchen/swagger/docgen/descriptionFile.txt
@@ -1,0 +1,1 @@
+Description file content


### PR DESCRIPTION
Hi and thanks for the great plugin 👍 

I found a potential resource leak in `AbstractDocumentSource`. The InputStream was not closed in the `finally` block so in case of an exception it would have never been closed.
I refactored this bit using try-with-resource so one can never even forget to close it in the first place :)