### PR TITLE
improve handling of @ResponseStatus annotation in SpringMVC

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
@@ -347,6 +347,8 @@ public abstract class AbstractReader {
     }
 
     protected void updateApiResponse(Operation operation, ApiResponses responseAnnotation) {
+        boolean contains200 = false;
+        boolean contains2xx = false;
         for (ApiResponse apiResponse : responseAnnotation.value()) {
             Map<String, Property> responseHeaders = parseResponseHeaders(apiResponse.responseHeaders());
             Class<?> responseClass = apiResponse.response();
@@ -393,6 +395,14 @@ public abstract class AbstractReader {
             } else {
                 operation.response(apiResponse.code(), response);
             }
+            if (apiResponse.code() == 200) {
+                contains200 = true;
+            } else if (apiResponse.code() > 200 && apiResponse.code() < 300) {
+                contains2xx = true;
+            }
+        }
+        if (!contains200 && contains2xx) {
+            operation.getResponses().remove("200");
         }
     }
 

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
@@ -402,7 +402,11 @@ public abstract class AbstractReader {
             }
         }
         if (!contains200 && contains2xx) {
-            operation.getResponses().remove("200");
+            Map<String, Response> responses = operation.getResponses();
+            //technically should not be possible at this point, added to be safe
+            if (responses != null) {
+                responses.remove("200");
+            }
         }
     }
 

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiReader.java
@@ -265,7 +265,7 @@ public class SpringMvcApiReader extends AbstractReader implements ClassSwaggerRe
         } else {
             ResponseStatus responseStatus = findMergedAnnotation(method, ResponseStatus.class);
             if (responseStatus != null) {
-                operation.response(responseStatus.value().value(), new Response().description(responseStatus.reason()));
+                updateResponseStatus(operation, responseStatus);
             }
         }
 
@@ -313,6 +313,22 @@ public class SpringMvcApiReader extends AbstractReader implements ClassSwaggerRe
         processOperationDecorator(operation, method);
 
         return operation;
+    }
+
+    private void updateResponseStatus(Operation operation, ResponseStatus responseStatus) {
+        int code = responseStatus.value().value();
+        String reason = responseStatus.reason();
+
+        if (operation.getResponses() != null && operation.getResponses().size() == 1) {
+            String currentKey = operation.getResponses().keySet().iterator().next();
+            Response oldResponse = operation.getResponses().remove(currentKey);
+            if (StringUtils.isNotEmpty(reason)) {
+                oldResponse.setDescription(reason);
+            }
+            operation.response(code, oldResponse);
+        } else {
+            operation.response(code, new Response().description(reason));
+        }
     }
 
     private Map<String, List<Method>> collectApisByRequestMapping(List<Method> methods) {

--- a/src/test/java/com/github/kongchen/swagger/docgen/spring/SpringMVCResponseStatusTest.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/spring/SpringMVCResponseStatusTest.java
@@ -1,0 +1,151 @@
+package com.github.kongchen.swagger.docgen.spring;
+
+import com.github.kongchen.swagger.docgen.GenerateException;
+import com.github.kongchen.swagger.docgen.reader.SpringMvcApiReader;
+import com.google.common.collect.ImmutableMap;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.jaxrs.ext.SwaggerExtension;
+import io.swagger.jaxrs.ext.SwaggerExtensions;
+import io.swagger.models.*;
+import org.apache.maven.plugin.logging.SystemStreamLog;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+
+public class SpringMVCResponseStatusTest {
+
+    private static final String REASON = "reason";
+    private static final String SUCCESSFUL_OPERATION_DESCRIPTION = "successful operation";
+    private static final String ACCEPTED_OPERATION_DESCRIPTION = "202 message";
+    private static final String CONFLICT_OPERATION_DESCRIPTION = "conflict message";
+    private static final Model RETURN_TYPE_STRING = new ModelImpl().type("string");
+    private static final Model RETURN_TYPE_INTEGER = new ModelImpl().type("integer").format("int32");
+
+
+    private List<SwaggerExtension> extensions = SwaggerExtensions.getExtensions();
+    private SpringMvcApiReader reader;
+
+    @BeforeMethod
+    public void setup() {
+        reader = new SpringMvcApiReader(new Swagger(), new SystemStreamLog());
+    }
+
+    @AfterMethod
+    public void resetExtenstions() {
+        SwaggerExtensions.setExtensions(extensions);
+    }
+
+    @Test
+    public void testStatusCommon() throws GenerateException {
+        testMethod("/getString", HttpMethod.GET,
+              ImmutableMap.of(
+                    HttpStatus.OK,
+                    new Response().description(SUCCESSFUL_OPERATION_DESCRIPTION).responseSchema(RETURN_TYPE_STRING))
+        );
+    }
+
+
+    @Test
+    public void testStatusOKOverridden() throws GenerateException {
+        testMethod("/getString_200", HttpMethod.GET,
+              ImmutableMap.of(
+                    HttpStatus.OK,
+                    new Response().description(REASON).responseSchema(RETURN_TYPE_STRING))
+        );
+    }
+
+
+    @Test
+    public void testAPIResponse() throws GenerateException {
+        testMethod("/getString_ApiResponse_202_409", HttpMethod.GET,
+              ImmutableMap.of(
+                    HttpStatus.ACCEPTED,
+                    new Response().description(ACCEPTED_OPERATION_DESCRIPTION),
+                    HttpStatus.CONFLICT,
+                    new Response().description(CONFLICT_OPERATION_DESCRIPTION))
+        );
+    }
+
+    @Test
+    public void testAPIResponseOverridden() throws GenerateException {
+        testMethod("/getString_ApiResponse_202_409_over", HttpMethod.GET,
+              ImmutableMap.of(
+                    HttpStatus.ACCEPTED,
+                    new Response().description(ACCEPTED_OPERATION_DESCRIPTION),
+                    HttpStatus.CONFLICT,
+                    new Response().description(CONFLICT_OPERATION_DESCRIPTION))
+        );
+    }
+
+
+    @Test
+    public void testStatusCreatedOverridden() throws GenerateException {
+        testMethod("/getString_201", HttpMethod.POST,
+              ImmutableMap.of(
+                    HttpStatus.CREATED,
+                    new Response().description(SUCCESSFUL_OPERATION_DESCRIPTION).responseSchema(RETURN_TYPE_INTEGER))
+        );
+    }
+
+    private void testMethod(String url, HttpMethod method, Map<HttpStatus, Response> expectedResults) throws GenerateException
+    {
+        Swagger result = reader.read(Collections.singleton(TestController.class));
+
+        Map<String, Response> responseMap = result.getPaths().get(url).getOperationMap().get(method).getResponses();
+        Assert.assertEquals(responseMap.size(), expectedResults.size());
+
+        for (Map.Entry<HttpStatus, Response> expectedResult : expectedResults.entrySet())
+        {
+            Response response = responseMap.get(expectedResult.getKey().toString());
+            Assert.assertNotNull(response);
+            Assert.assertEquals(response.getDescription(), expectedResult.getValue().getDescription());
+            Assert.assertEquals(response.getResponseSchema(), expectedResult.getValue().getResponseSchema());
+        }
+    }
+
+    @RestController
+    private static class TestController {
+
+        @GetMapping("/getString")
+        public String getString() {
+            return "";
+        }
+
+        @GetMapping("/getString_200")
+        @ResponseStatus(value = HttpStatus.OK, reason = REASON)
+        public String getStringWithStatus() {
+            return "";
+        }
+
+        @PostMapping("/getString_201")
+        @ResponseStatus(HttpStatus.CREATED)
+        public Integer postAndGetStatus() {
+            return 0;
+        }
+
+        @GetMapping("/getString_ApiResponse_202_409")
+        @ApiResponses({@ApiResponse(code = 202, message = ACCEPTED_OPERATION_DESCRIPTION, response = String.class), @ApiResponse(code = 409, message = CONFLICT_OPERATION_DESCRIPTION)})
+        public String getStringAPIResponse() {
+            return "";
+        }
+
+        @ResponseStatus(code = HttpStatus.ACCEPTED)
+        @GetMapping("/getString_ApiResponse_202_409_over")
+        @ApiResponses({@ApiResponse(code = 202, message = ACCEPTED_OPERATION_DESCRIPTION, response = Integer.class), @ApiResponse(code = 409, message = CONFLICT_OPERATION_DESCRIPTION)})
+        public Integer getStringAPIResponseOverridden() {
+            return 0;
+        }
+    }
+}

--- a/src/test/java/com/github/kongchen/swagger/docgen/spring/SpringMVCResponseStatusTest.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/spring/SpringMVCResponseStatusTest.java
@@ -38,7 +38,7 @@ public class SpringMVCResponseStatusTest {
     private SpringMvcApiReader reader;
 
     @BeforeMethod
-    public void setup() {
+    public void setUp() {
         reader = new SpringMvcApiReader(new Swagger(), new SystemStreamLog());
     }
 


### PR DESCRIPTION
This PR improves handing of the ResponseStatus annotation and also fixes https://github.com/kongchen/swagger-maven-plugin/issues/716

According to the documentation, it should override all successful response with specified code, but unless only one response is available, we cannot decide on the schema to use, so additional check for `operation.getResponses().size() == 1` is performed. Otherwise I fallback to the previous behaviour