### PR TITLE
Fix propagation of primitive schema from ApiResponse

### DIFF
--- a/src/test/java/com/github/kongchen/swagger/docgen/spring/SpringMVCResponseStatusTest.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/spring/SpringMVCResponseStatusTest.java
@@ -72,7 +72,7 @@ public class SpringMVCResponseStatusTest {
         testMethod("/getString_ApiResponse_202_409", HttpMethod.GET,
               ImmutableMap.of(
                     HttpStatus.ACCEPTED,
-                    new Response().description(ACCEPTED_OPERATION_DESCRIPTION),
+                    new Response().description(ACCEPTED_OPERATION_DESCRIPTION).responseSchema(RETURN_TYPE_STRING),
                     HttpStatus.CONFLICT,
                     new Response().description(CONFLICT_OPERATION_DESCRIPTION))
         );
@@ -83,7 +83,7 @@ public class SpringMVCResponseStatusTest {
         testMethod("/getString_ApiResponse_202_409_over", HttpMethod.GET,
               ImmutableMap.of(
                     HttpStatus.ACCEPTED,
-                    new Response().description(ACCEPTED_OPERATION_DESCRIPTION),
+                    new Response().description(ACCEPTED_OPERATION_DESCRIPTION).responseSchema(RETURN_TYPE_INTEGER),
                     HttpStatus.CONFLICT,
                     new Response().description(CONFLICT_OPERATION_DESCRIPTION))
         );

--- a/src/test/resources/expectedOutput/swagger-enhanced-operation-id.json
+++ b/src/test/resources/expectedOutput/swagger-enhanced-operation-id.json
@@ -1298,7 +1298,13 @@
         "produces" : [ "application/json" ],
         "responses" : {
           "200" : {
-            "description" : "Successful operation"
+              "description": "Successful operation",
+              "schema": {
+                  "type": "array",
+                  "items": {
+                      "type": "object"
+                  }
+              }
           }
         },
         "security" : [ {

--- a/src/test/resources/expectedOutput/swagger-enhanced-operation-id.json
+++ b/src/test/resources/expectedOutput/swagger-enhanced-operation-id.json
@@ -1298,13 +1298,13 @@
         "produces" : [ "application/json" ],
         "responses" : {
           "200" : {
-              "description": "Successful operation",
-              "schema": {
-                  "type": "array",
-                  "items": {
-                      "type": "object"
-                  }
+            "description": "Successful operation",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "object"
               }
+            }
           }
         },
         "security" : [ {

--- a/src/test/resources/expectedOutput/swagger-externalDocs.json
+++ b/src/test/resources/expectedOutput/swagger-externalDocs.json
@@ -1647,7 +1647,13 @@
         "produces" : [ "application/json" ],
         "responses" : {
           "200" : {
-            "description" : "Successful operation"
+              "description": "Successful operation",
+              "schema": {
+                  "type": "array",
+                  "items": {
+                      "type": "object"
+                  }
+              }
           }
         },
         "security" : [ {

--- a/src/test/resources/expectedOutput/swagger-externalDocs.json
+++ b/src/test/resources/expectedOutput/swagger-externalDocs.json
@@ -1647,13 +1647,13 @@
         "produces" : [ "application/json" ],
         "responses" : {
           "200" : {
-              "description": "Successful operation",
-              "schema": {
-                  "type": "array",
-                  "items": {
-                      "type": "object"
-                  }
+            "description": "Successful operation",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "object"
               }
+            }
           }
         },
         "security" : [ {

--- a/src/test/resources/expectedOutput/swagger-with-converter.json
+++ b/src/test/resources/expectedOutput/swagger-with-converter.json
@@ -1642,13 +1642,13 @@
         "produces" : [ "application/json" ],
         "responses" : {
           "200" : {
-              "description": "Successful operation",
-              "schema": {
-                  "type": "array",
-                  "items": {
-                      "type": "object"
-                  }
+            "description": "Successful operation",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "object"
               }
+            }
           }
         },
         "security" : [ {

--- a/src/test/resources/expectedOutput/swagger-with-converter.json
+++ b/src/test/resources/expectedOutput/swagger-with-converter.json
@@ -1642,7 +1642,13 @@
         "produces" : [ "application/json" ],
         "responses" : {
           "200" : {
-            "description" : "Successful operation"
+              "description": "Successful operation",
+              "schema": {
+                  "type": "array",
+                  "items": {
+                      "type": "object"
+                  }
+              }
           }
         },
         "security" : [ {

--- a/src/test/resources/expectedOutput/swagger-with-converter.yaml
+++ b/src/test/resources/expectedOutput/swagger-with-converter.yaml
@@ -1162,6 +1162,10 @@ paths:
       responses:
         200:
           description: "Successful operation"
+          schema:
+            type: array
+            items:
+              type: object
       security:
       - api_key: []
     put:

--- a/src/test/resources/expectedOutput/swagger.json
+++ b/src/test/resources/expectedOutput/swagger.json
@@ -1651,7 +1651,7 @@
             "schema": {
               "type": "array",
               "items": {
-                "type": "object",
+                "type": "object"
               }
             }
           }

--- a/src/test/resources/expectedOutput/swagger.json
+++ b/src/test/resources/expectedOutput/swagger.json
@@ -1649,10 +1649,10 @@
           "200" : {
             "description" : "Successful operation",
             "schema": {
-                "type": "array",
-                "items": {
-                    "type": "object"
-                }
+              "type": "array",
+              "items": {
+                "type": "object",
+              }
             }
           }
         },

--- a/src/test/resources/expectedOutput/swagger.json
+++ b/src/test/resources/expectedOutput/swagger.json
@@ -1647,7 +1647,13 @@
         "produces" : [ "application/json" ],
         "responses" : {
           "200" : {
-            "description" : "Successful operation"
+            "description" : "Successful operation",
+            "schema": {
+                "type": "array",
+                "items": {
+                    "type": "object"
+                }
+            }
           }
         },
         "security" : [ {

--- a/src/test/resources/expectedOutput/swagger.yaml
+++ b/src/test/resources/expectedOutput/swagger.yaml
@@ -1162,6 +1162,10 @@ paths:
       responses:
         200:
           description: "Successful operation"
+          schema:
+            type: array
+            items:
+              type: object
       security:
       - api_key: []
     put:

--- a/src/test/resources/sample.html
+++ b/src/test/resources/sample.html
@@ -3545,7 +3545,7 @@ Get user list
 
 | Status Code | Reason      | Response Model |
 |-------------|-------------|----------------|
-| 200    | Successful operation |  - |
+| 200    | Successful operation | Array[<a href=""></a>]|
 
 
 


### PR DESCRIPTION
Currently `response` field in `@ApiResponse` annotation is ignored when its value is of primitive type (string, integer, list, map, ...). 

This PR fixes this behaviour and allows primitive types to be propagated into response's schema.