### PR TITLE
Feature/completion stage support

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
@@ -15,6 +15,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletionStage;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -387,6 +388,13 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
             // pick out response from method declaration
             LOGGER.debug("picking up response class from method " + method);
             responseClassType = method.getGenericReturnType();
+            if(responseClassType instanceof ParameterizedType) {
+                ParameterizedType responseClassTypeImpl = (ParameterizedType) responseClassType;
+                if(CompletionStage.class.isAssignableFrom((Class) responseClassTypeImpl.getRawType())) {
+                    responseClassTypeImpl.getRawType();
+                    responseClassType = responseClassTypeImpl.getActualTypeArguments()[0];
+                }
+            }
         }
         boolean hasApiAnnotation = false;
         if (responseClassType instanceof Class) {

--- a/src/test/java/com/github/kongchen/swagger/docgen/reader/JaxrsReaderTest.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/reader/JaxrsReaderTest.java
@@ -218,17 +218,17 @@ public class JaxrsReaderTest {
         assertFalse(properties.containsKey("inheritedProperty"));
         assertFalse(properties.containsKey("type"));
 
-        properties = getProperties(models, "SomeResponseInterface");
+        properties = getProperties(models,"SomeResponseInterface");
         assertNotNull(properties);
         assertTrue(properties.containsKey("inheritedProperty"));
         assertTrue(properties.containsKey("type"));
 
-        properties = getProperties(models, "SomeResponse");
+        properties = getProperties(models,"SomeResponse");
         assertNotNull(properties);
         assertTrue(properties.containsKey("classProperty"));
         assertTrue(properties.containsKey("type"));
 
-        properties = getProperties(models, "SomeOtherResponse");
+        properties = getProperties(models,"SomeOtherResponse");
         assertNotNull(properties);
         assertTrue(properties.containsKey("classProperty"));
         assertTrue(properties.containsKey("type"));
@@ -352,7 +352,8 @@ public class JaxrsReaderTest {
         @ApiOperation(value = "Add content")
         @Consumes(MediaType.APPLICATION_OCTET_STREAM)
         public void addOperation(
-            @ApiParam(value = "content", required = true, type = "string", format = "byte") final byte[] content) {
+                @ApiParam(value = "content", required = true, type = "string", format = "byte")
+                    final byte[] content) {
         }
     }
 
@@ -364,9 +365,8 @@ public class JaxrsReaderTest {
             // no implementation needed. Method is only for the test cases, so that the return type is captured
             return new SomeSubResource();
         }
-
         @Path("implicit")
-        @ApiOperation(value = "", response = SomeSubResource.class)
+        @ApiOperation(value="", response = SomeSubResource.class)
         public Object getSomeSub() {
             // no implementation needed. Method is only for the test cases, so that the return type is overridden by @ApiOperation.response
             return new SomeSubResource();
@@ -391,14 +391,10 @@ public class JaxrsReaderTest {
         }
 
         @GET
-        public SomeResponseBaseClass getOperation2() {
-            return null;
-        }
+        public SomeResponseBaseClass getOperation2() { return null; }
 
         @GET
-        public SomeResponseWithInterfaceInheritance getOperation3() {
-            return null;
-        }
+        public SomeResponseWithInterfaceInheritance getOperation3() { return null; }
 
         @GET
         public SomeResponseInterface getOperation4() {
@@ -406,14 +402,10 @@ public class JaxrsReaderTest {
         }
 
         @GET
-        public List<SomeResponse> getOperation5() {
-            return null;
-        }
+        public List<SomeResponse> getOperation5() { return null; }
 
         @GET
-        public SomeOtherResponse[] getOperation6() {
-            return null;
-        }
+        public SomeOtherResponse[] getOperation6() { return null; }
     }
 
     @Api
@@ -421,70 +413,59 @@ public class JaxrsReaderTest {
     static class AnApiWithCompletionStage {
         @Path("a")
         @GET
-        public CompletableFuture<String> getOperation1() {
-            return null;
-        }
+        public CompletableFuture<String> getOperation1() { return null; }
 
         @Path("b")
         @GET
-        public CompletionStage<String> getOperation2() {
-            return null;
-        }
+        public CompletionStage<String> getOperation2() { return null; }
 
         @Path("c")
         @GET
-        public String getOperation3() {
-            return null;
-        }
+        public String getOperation3() { return null; }
     }
 
-    @JsonTypeInfo(use = Id.NAME, property = "type")
+    @JsonTypeInfo(use=Id.NAME, property="type")
     static class SomeResponseWithAbstractInheritance extends SomeResponseBaseClass {
-        public String getClassProperty() {
+        public String getClassProperty(){
             return null;
         }
     }
 
-    @JsonTypeInfo(use = Id.NAME, property = "type")
+    @JsonTypeInfo(use=Id.NAME, property="type")
     @JsonSubTypes({
-        @JsonSubTypes.Type(SomeResponseWithAbstractInheritance.class)
+            @JsonSubTypes.Type(SomeResponseWithAbstractInheritance.class)
     })
     static abstract class SomeResponseBaseClass {
-        public String getInheritedProperty() {
+        public String getInheritedProperty(){
             return null;
         }
     }
 
-    @JsonTypeInfo(use = Id.NAME, property = "type")
+    @JsonTypeInfo(use=Id.NAME, property="type")
     static class SomeResponseWithInterfaceInheritance implements SomeResponseInterface {
-        public String getClassProperty() {
+        public String getClassProperty(){
             return null;
         }
-
-        public String getInheritedProperty() {
+        public String getInheritedProperty(){
             return null;
         }
     }
 
-    @JsonTypeInfo(use = Id.NAME, property = "type")
+    @JsonTypeInfo(use=Id.NAME, property="type")
     @JsonSubTypes({
-        @JsonSubTypes.Type(SomeResponseWithInterfaceInheritance.class)
+            @JsonSubTypes.Type(SomeResponseWithInterfaceInheritance.class)
     })
     interface SomeResponseInterface {
         String getInheritedProperty();
     }
 
-    @JsonTypeInfo(use = Id.NAME, property = "type")
+    @JsonTypeInfo(use=Id.NAME, property="type")
     static class SomeResponse {
-        public String getClassProperty() {
-            return null;
-        }
+        public String getClassProperty() { return null; }
     }
 
-    @JsonTypeInfo(use = Id.NAME, property = "type")
+    @JsonTypeInfo(use=Id.NAME, property="type")
     static class SomeOtherResponse {
-        public String getClassProperty() {
-            return null;
-        }
+        public String getClassProperty() { return null; }
     }
 }

--- a/src/test/java/com/github/kongchen/swagger/docgen/reader/JaxrsReaderTest.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/reader/JaxrsReaderTest.java
@@ -3,6 +3,35 @@ package com.github.kongchen.swagger.docgen.reader;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import io.swagger.models.ComposedModel;
+import io.swagger.models.Model;
+import io.swagger.models.properties.Property;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import io.swagger.models.utils.PropertyModelConverter;
+import io.swagger.util.Json;
+import org.apache.maven.plugin.logging.Log;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -12,32 +41,22 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.jaxrs.ext.SwaggerExtension;
 import io.swagger.jaxrs.ext.SwaggerExtensions;
-import io.swagger.models.*;
-import io.swagger.models.parameters.*;
-import io.swagger.models.properties.Property;
-import io.swagger.models.utils.PropertyModelConverter;
-import io.swagger.util.Json;
+import io.swagger.models.ArrayModel;
+import io.swagger.models.Operation;
+import io.swagger.models.Swagger;
+import io.swagger.models.Tag;
+import io.swagger.models.parameters.BodyParameter;
+import io.swagger.models.parameters.HeaderParameter;
+import io.swagger.models.parameters.Parameter;
+import io.swagger.models.parameters.QueryParameter;
+import io.swagger.models.parameters.RefParameter;
 import net.javacrumbs.jsonunit.JsonAssert;
-import org.apache.maven.plugin.logging.Log;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 
-import javax.ws.rs.Path;
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 public class JaxrsReaderTest {
     @Mock


### PR DESCRIPTION
This would ignore any `CompletionStage` or child, and would return `T`

Since JAXRS2.1, CompletionStage is now supported, and  the server would only return the generic type.