### PR TITLE
Reader have to consider Deprecated annotation when placed on class

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
@@ -156,6 +156,10 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
                 String httpMethod = extractOperationMethod(apiOperation, method, SwaggerExtensions.chain());
 
                 Operation operation = parseMethod(httpMethod, method);
+                if (AnnotationUtils.findAnnotation(cls, Deprecated.class) != null) {
+                    operation.deprecated(true);
+                }
+
                 updateOperationParameters(parentParameters, regexMap, operation);
                 updateOperationProtocols(apiOperation, operation);
 

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiReader.java
@@ -117,6 +117,9 @@ public class SpringMvcApiReader extends AbstractReader implements ClassSwaggerRe
                 for (RequestMethod requestMethod : requestMapping.method()) {
                     String httpMethod = requestMethod.toString().toLowerCase();
                     Operation operation = parseMethod(method, requestMethod);
+                    if (findAnnotation(resource.getControllerClass(), Deprecated.class) != null) {
+                        operation.deprecated(true);
+                    }
 
                     updateOperationParameters(new ArrayList<Parameter>(), regexMap, operation);
 
@@ -278,8 +281,7 @@ public class SpringMvcApiReader extends AbstractReader implements ClassSwaggerRe
 
         overrideResponseMessages(operation);
 
-        Deprecated annotation = findAnnotation(method, Deprecated.class);
-        if (annotation != null) {
+        if (findAnnotation(method, Deprecated.class) != null) {
             operation.deprecated(true);
         }
 

--- a/src/test/java/com/github/kongchen/swagger/docgen/reader/JaxrsReaderTest.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/reader/JaxrsReaderTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import io.swagger.models.ComposedModel;
+import io.swagger.models.HttpMethod;
 import io.swagger.models.Model;
 import io.swagger.models.properties.Property;
 import java.util.ArrayList;
@@ -29,7 +30,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -115,6 +115,12 @@ public class JaxrsReaderTest {
         Swagger result = nullReader.read(AnApi.class);
 
         assertSwaggerResponseContents(expectedTag, result);
+    }
+
+    @Test
+    public void verifyDeprecatedAnnotationOnClass() {
+        Swagger deprecated = reader.read(ADeprecatedApi.class);
+        assertTrue(deprecated.getPath("/deprecatedpath").getOperationMap().get(HttpMethod.GET).isDeprecated(), "method is not marked as deprecated");
     }
 
     @Test
@@ -336,6 +342,19 @@ public class JaxrsReaderTest {
         public void addOperation(
                 @ApiParam(value = "content", required = true, type = "string", format = "byte")
                     final byte[] content) {
+        }
+    }
+
+    @Path("/deprecatedpath")
+    @Deprecated
+    static class ADeprecatedApi extends NonDeprecatedApi {
+    }
+
+    @Path("/apath")
+    static class NonDeprecatedApi {
+        @GET
+        public String get() {
+            return null;
         }
     }
 


### PR DESCRIPTION
This PR fix #766, now Deprecated annotation on class is taken into account.

Example
```
    @Path("/pathA")
    public class NonDeprecatedApi extends DeprecatedApi {
        @DELETE
        public int remove() {
            return 0;
        }
    }

    @Deprecated
    public class DeprecatedApi {
        @GET
        public String get() {
            return null;
        }
    }
```

Where:
- DELETE /pathA is **not** deprecated
- GET /pathA **is** deprecated
