### PR TITLE
fix bug: recognize spring HttpHeaders as a request body

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ before_install:
 
 install:
 
-
+dist: trusty
 

--- a/src/main/java/com/github/kongchen/swagger/docgen/spring/SpringSwaggerExtension.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/spring/SpringSwaggerExtension.java
@@ -319,6 +319,7 @@ public class SpringSwaggerExtension extends AbstractSwaggerExtension {
         }
 
         return clazzName.startsWith("org.springframework") &&
-                !"org.springframework.web.multipart.MultipartFile".equals(clazzName);
+                !"org.springframework.web.multipart.MultipartFile".equals(clazzName) &&
+                !"org.springframework.http.HttpHeaders".equals(clazzName);
     }
 }


### PR DESCRIPTION
There is a simple issue with ```SpringMvcApiReader```: 
```java
import org.springframework.http.HttpHeaders;

@RequestMapping("/some/path")
class SomeResourceWithClassOnlyPaths {
    @RequestMapping(value="", method=RequestMethod.GET)
    public String get(@RequestHeader HttpHeaders headers, @RequestBody Map<String, String> body) { return null; }
}
```
I try to invoke ```SpringMvcApiReader.read``` to return a Swagger Object, and I find my first param ```org.springframework.http.HttpHeaders headers``` will be ignored and then recognized as a "body" type, and this will cover the definition of real body ```Map<String, String> body``` 

---------
```json
{"paths":{"/some/path":{"empty":false,"get":{"operationId":"get","parameters":[{"in":"body","name":"body","required":false,"schema":{"additionalProperties":{"items":{"required":false,"type":"string","vendorExtensions":{}},"required":false,"type":"array","vendorExtensions":{}},"simple":false,"type":"object","vendorExtensions":{}},"vendorExtensions":{}},{"in":"body","name":"body","required":false,"schema":{"additionalProperties":{"required":false,"type":"string","vendorExtensions":{}},"simple":false,"type":"object","vendorExtensions":{}},"vendorExtensions":{}}],"responses":{"200":{"description":"successful operation","responseSchema":{"simple":false,"type":"string","vendorExtensions":{}},"schema":{"required":false,"type":"string","vendorExtensions":{"$ref":"$.paths.\\/some\\/path.get.responses.200.responseSchema.vendorExtensions"}},"vendorExtensions":{}}},"vendorExtensions":{}},"operationMap":{"GET":{"$ref":"$.paths.\\/some\\/path.get"}},"operations":[{"$ref":"$.paths.\\/some\\/path.get"}],"vendorExtensions":{}}},"swagger":"2.0"}
```
