### PR TITLE
Adjust error message

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/AbstractDocumentSource.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/AbstractDocumentSource.java
@@ -216,9 +216,11 @@ public abstract class AbstractDocumentSource<D extends AbstractReader & ClassSwa
                     case yaml:
                         FileUtils.write(new File(dir, fileName + ".yaml"), Yaml.pretty().writeValueAsString(swagger), encoding);
                         break;
+                    default:
+                        throw new GenerateException(String.format("Declared output format [%s] is not supported.", format));
                 }
             } catch (Exception e) {
-                throw new GenerateException(String.format("Declared output format [%s] is not supported.", format));
+                throw new GenerateException(String.format("Got exception while writing file. (format=%s, errorMessage=%s)", format, e.getMessage()));
             }
         }
     }


### PR DESCRIPTION
To give a better picture of what failed. I had a permission issue on the path where I wanted the swagger file to end put, and I got the error `Declared output format [json] is not supported.`. This was misleading, as the actual exception was a permission denied error.