### PR TITLE
fixes and improvements in operationIdFormat

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
@@ -523,13 +523,14 @@ public abstract class AbstractReader {
         }
     }
     
-    protected String getOperationId(String operationPath, Class<?> controller, String methodName, String httpMethod) {
+    protected String getOperationId(String operationPath, Class<?> controller, Method method, String httpMethod) {
   		if (this.operationIdFormat == null) {
   			this.operationIdFormat = OPERATION_ID_FORMAT_DEFAULT;
   		}
   		
   		String packageName = controller.getPackage().getName();
   		String className = controller.getSimpleName();
+        String methodName = method.getName();
         
   		StrBuilder sb = new StrBuilder(this.operationIdFormat);
   		sb.replaceAll("{{packageName}}", packageName);

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java
@@ -523,20 +523,20 @@ public abstract class AbstractReader {
         }
     }
     
-    protected String getOperationId(Method method, String httpMethod) {
+    protected String getOperationId(String operationPath, Class<?> controller, String methodName, String httpMethod) {
   		if (this.operationIdFormat == null) {
   			this.operationIdFormat = OPERATION_ID_FORMAT_DEFAULT;
   		}
   		
-  		String packageName = method.getDeclaringClass().getPackage().getName();
-  		String className = method.getDeclaringClass().getSimpleName();
-  		String methodName = method.getName();
+  		String packageName = controller.getPackage().getName();
+  		String className = controller.getSimpleName();
         
   		StrBuilder sb = new StrBuilder(this.operationIdFormat);
   		sb.replaceAll("{{packageName}}", packageName);
   		sb.replaceAll("{{className}}", className);
   		sb.replaceAll("{{methodName}}", methodName);
-  		sb.replaceAll("{{httpMethod}}", httpMethod);
+        sb.replaceAll("{{httpMethod}}", httpMethod);
+        sb.replaceAll("{{path}}", operationPath);
   		
   		return sb.toString();
     }

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
@@ -155,7 +155,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
 
                 String httpMethod = extractOperationMethod(apiOperation, method, SwaggerExtensions.chain());
 
-                Operation operation = parseMethod(httpMethod, method);
+                Operation operation = parseMethod(operationPath, cls, httpMethod, method);
                 updateOperationParameters(parentParameters, regexMap, operation);
                 updateOperationProtocols(apiOperation, operation);
 
@@ -331,12 +331,12 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
     }
 
 
-    public Operation parseMethod(String httpMethod, Method method) {
+    public Operation parseMethod(String path, Class<?> controller, String httpMethod, Method method) {
         int responseCode = 200;
         Operation operation = new Operation();
         ApiOperation apiOperation = AnnotationUtils.findAnnotation(method, ApiOperation.class);
 
-        String operationId = getOperationId(method, httpMethod);
+        String operationId = getOperationId(path, controller, method.getName(), httpMethod);
 
         String responseContainer = null;
 

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
@@ -336,7 +336,7 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
         Operation operation = new Operation();
         ApiOperation apiOperation = AnnotationUtils.findAnnotation(method, ApiOperation.class);
 
-        String operationId = getOperationId(path, controller, method.getName(), httpMethod);
+        String operationId = getOperationId(path, controller, method, httpMethod);
 
         String responseContainer = null;
 

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiReader.java
@@ -149,7 +149,7 @@ public class SpringMvcApiReader extends AbstractReader implements ClassSwaggerRe
         List<String> produces = new ArrayList<String>();
         List<String> consumes = new ArrayList<String>();
         String responseContainer = null;
-        String operationId = getOperationId(operationPath, controller, method.getName(), requestMethod.name());
+        String operationId = getOperationId(operationPath, controller, method, requestMethod.name());
         Map<String, Property> defaultResponseHeaders = null;
 
         ApiOperation apiOperation = findMergedAnnotation(method, ApiOperation.class);

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiReader.java
@@ -116,7 +116,7 @@ public class SpringMvcApiReader extends AbstractReader implements ClassSwaggerRe
                 //http method
                 for (RequestMethod requestMethod : requestMapping.method()) {
                     String httpMethod = requestMethod.toString().toLowerCase();
-                    Operation operation = parseMethod(method, requestMethod);
+                    Operation operation = parseMethod(operationPath, controller, method, requestMethod);
 
                     updateOperationParameters(new ArrayList<Parameter>(), regexMap, operation);
 
@@ -140,7 +140,7 @@ public class SpringMvcApiReader extends AbstractReader implements ClassSwaggerRe
         return swagger;
     }
 
-    private Operation parseMethod(Method method, RequestMethod requestMethod) {
+    private Operation parseMethod(String operationPath, Class<?> controller, Method method, RequestMethod requestMethod) {
         int responseCode = 200;
         Operation operation = new Operation();
 
@@ -149,7 +149,7 @@ public class SpringMvcApiReader extends AbstractReader implements ClassSwaggerRe
         List<String> produces = new ArrayList<String>();
         List<String> consumes = new ArrayList<String>();
         String responseContainer = null;
-        String operationId = getOperationId(method, requestMethod.name());
+        String operationId = getOperationId(operationPath, controller, method.getName(), requestMethod.name());
         Map<String, Property> defaultResponseHeaders = null;
 
         ApiOperation apiOperation = findMergedAnnotation(method, ApiOperation.class);


### PR DESCRIPTION
adds {{path}} token to operationIdFormat
uses real endpoint class' {{className}} and {{packageName}} instead of class/package of compilation unit where swagger and/or jaxrs/spring annotations are placed