### PR TITLE
[wip] Add support for openapi output

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ The `executions` block is used to specify the phase of the build lifecycle you w
 | `operationIdFormat` | Format of `operationId` used in Swagger spec. For historical reasons default is Java method name. Since 3.1.8, for new APIs suggested format is: `{{className}}_{{methodName}}_{{httpMethod}}`. `{{packageName}}` token is also supported. |
 | `externalDocs` | URL Reference to external documentation |
 | `responseMessageOverrides` | Default response message overrides of type ```@ApiResponse```. Example: `<responseMessageOverrides><responseMessageOverride><code>401</code><message>Unauthenticated - could not authenticate the user.</message></responseMessageOverride></responseMessageOverrides>` |
+| `specification` | Output specification. Should be either `swagger` (default) or `openapi`. Works in conjunction with `specificationVersion` |
+| `specificationVersion` | Output specification version. Defaults to `2.0` (which will give `swagger: 2.0` for default `specificagtion` value) |
 # <a id="templatefile">Template File</a>
 
 If you'd like to generate a template-driven static document, such as markdown or HTML documentation, you'll need to specify a [handlebars](https://github.com/jknack/handlebars.java) template file in ```templatePath```.

--- a/src/main/java/com/github/kongchen/swagger/docgen/AbstractDocumentSource.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/AbstractDocumentSource.java
@@ -56,7 +56,6 @@ public abstract class AbstractDocumentSource<D extends AbstractReader & ClassSwa
     protected final Log LOG;
     protected final List<Type> typesToSkip = new ArrayList<Type>();
     protected Swagger swagger;
-    protected String swaggerSchemaConverter;
     private final String outputPath;
     private final String templatePath;
     private final String swaggerPath;
@@ -66,7 +65,7 @@ public abstract class AbstractDocumentSource<D extends AbstractReader & ClassSwa
     private boolean isSorted = false;
     protected String encoding = "UTF-8";
 
-    public AbstractDocumentSource(Log log, ApiSource apiSource, String encoding) throws MojoFailureException {
+    public AbstractDocumentSource(Log log, ApiSource apiSource, String encoding, String specification, String specificationVersion) throws MojoFailureException {
         LOG = log;
         this.outputPath = apiSource.getOutputPath();
         this.templatePath = apiSource.getTemplatePath();
@@ -74,7 +73,12 @@ public abstract class AbstractDocumentSource<D extends AbstractReader & ClassSwa
         this.modelSubstitute = apiSource.getModelSubstitute();
         this.jsonExampleValues = apiSource.isJsonExampleValues();
 
-        swagger = new Swagger();
+        if (specification.toLowerCase().equals("openapi")) {
+            swagger = new OpenApi(specificationVersion);
+        } else {
+            swagger = new Swagger();
+        }
+
         if (apiSource.getSchemes() != null) {
             for (String scheme : apiSource.getSchemes()) {
                 swagger.scheme(Scheme.forValue(scheme));

--- a/src/main/java/com/github/kongchen/swagger/docgen/OpenApi.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/OpenApi.java
@@ -1,0 +1,20 @@
+package com.github.kongchen.swagger.docgen;
+
+import io.swagger.models.Swagger;
+
+public class OpenApi extends Swagger {
+    private String openapi;
+
+    public OpenApi(String version) {
+        this.openapi = version;
+        this.swagger = null;
+    }
+
+    public String getOpenapi() {
+        return openapi;
+    }
+
+    public void setOpenapi(String openapi) {
+        this.openapi = openapi;
+    }
+}

--- a/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiDocumentMojo.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiDocumentMojo.java
@@ -18,8 +18,6 @@ import org.apache.maven.project.MavenProjectHelper;
 import java.io.File;
 import java.lang.reflect.Method;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * User: kongchen
@@ -51,6 +49,12 @@ public class ApiDocumentMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}", readonly = true)
     private MavenProject project;
+
+    @Parameter(defaultValue = "swagger")
+    private String specification;
+
+    @Parameter(defaultValue = "2.0")
+    private String specificationVersion;
 
     private String projectEncoding;
 
@@ -103,18 +107,17 @@ public class ApiDocumentMojo extends AbstractMojo {
 
             if (enabledObjectMapperFeatures!=null) {
                 configureObjectMapperFeatures(enabledObjectMapperFeatures,true);
-                
             }
 
             if (disabledObjectMapperFeatures!=null) {
                 configureObjectMapperFeatures(disabledObjectMapperFeatures,false);
             }
-            
+
             for (ApiSource apiSource : apiSources) {
                 validateConfiguration(apiSource);
                 AbstractDocumentSource documentSource = apiSource.isSpringmvc()
-                        ? new SpringMavenDocumentSource(apiSource, getLog(), projectEncoding)
-                        : new MavenDocumentSource(apiSource, getLog(), projectEncoding);
+                        ? new SpringMavenDocumentSource(apiSource, getLog(), projectEncoding, specification, specificationVersion)
+                        : new MavenDocumentSource(apiSource, getLog(), projectEncoding, specification, specificationVersion);
 
                 documentSource.loadTypesToSkip();
                 documentSource.loadModelModifier();
@@ -214,7 +217,7 @@ public class ApiDocumentMojo extends AbstractMojo {
     }
 
     private String getSwaggerFileName(String swaggerFileName) {
-        return swaggerFileName == null || "".equals(swaggerFileName.trim()) ? "swagger" : swaggerFileName;
+        return swaggerFileName == null || "".equals(swaggerFileName.trim()) ? specification : swaggerFileName;
     }
 
     private String getSwaggerDirectoryName(String swaggerDirectory) {

--- a/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/MavenDocumentSource.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/MavenDocumentSource.java
@@ -15,8 +15,8 @@ import java.util.Set;
  */
 public class MavenDocumentSource extends AbstractDocumentSource<JaxrsReader> {
 
-    public MavenDocumentSource(ApiSource apiSource, Log log, String encoding) throws MojoFailureException {
-        super(log, apiSource, encoding);
+    public MavenDocumentSource(ApiSource apiSource, Log log, String encoding, String specification, String specificationVersion) throws MojoFailureException {
+        super(log, apiSource, encoding, specification, specificationVersion);
     }
 
     @Override

--- a/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/SpringMavenDocumentSource.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/SpringMavenDocumentSource.java
@@ -17,8 +17,8 @@ import java.util.Set;
  */
 public class SpringMavenDocumentSource extends AbstractDocumentSource<SpringMvcApiReader> {
 
-    public SpringMavenDocumentSource(ApiSource apiSource, Log log, String encoding) throws MojoFailureException {
-        super(log, apiSource, encoding);
+    public SpringMavenDocumentSource(ApiSource apiSource, Log log, String encoding, String specification, String specificationVersion) throws MojoFailureException {
+        super(log, apiSource, encoding, specification, specificationVersion);
     }
 
     @Override

--- a/src/test/java/com/github/kongchen/swagger/docgen/AbstractDocumentSourceTest.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/AbstractDocumentSourceTest.java
@@ -35,7 +35,7 @@ public class AbstractDocumentSourceTest {
     @BeforeMethod
     public void setUp() throws MojoFailureException {
         MockitoAnnotations.initMocks(this);
-        source = new AbstractDocumentSource(log, apiSource, null) {
+        source = new AbstractDocumentSource(log, apiSource, null, "swagger", "2.0") {
             @Override
             protected ClassSwaggerReader resolveApiReader() throws GenerateException {
                 return null;
@@ -71,7 +71,7 @@ public class AbstractDocumentSourceTest {
         when(apiSource.getExternalDocs()).thenReturn(new ExternalDocs("Example external docs", "https://example.com/docs"));
 
         // act
-        AbstractDocumentSource externalDocsSource = new AbstractDocumentSource(log, apiSource, null) {
+        AbstractDocumentSource externalDocsSource = new AbstractDocumentSource(log, apiSource, null, "swagger", "2.0") {
             @Override
             protected ClassSwaggerReader resolveApiReader() throws GenerateException {
                 return null;
@@ -100,7 +100,7 @@ public class AbstractDocumentSourceTest {
         when(apiSource.getInfo()).thenReturn(new Info());
 
         // act
-        AbstractDocumentSource externalDocsSource = new AbstractDocumentSource(log, apiSource, "UTF-8") {
+        AbstractDocumentSource externalDocsSource = new AbstractDocumentSource(log, apiSource, "UTF-8", "swagger", "2.0") {
             @Override
             protected ClassSwaggerReader resolveApiReader() throws GenerateException {
                 return null;

--- a/src/test/java/com/github/kongchen/swagger/docgen/mavenplugin/SpringMavenDocumentSourceTest.java
+++ b/src/test/java/com/github/kongchen/swagger/docgen/mavenplugin/SpringMavenDocumentSourceTest.java
@@ -22,7 +22,7 @@ public class SpringMavenDocumentSourceTest
         apiSource.setLocations(Collections.singletonList(this.getClass().getPackage().getName()));
         apiSource.setSwaggerDirectory("./");
 
-        SpringMavenDocumentSource springMavenDocumentSource = new SpringMavenDocumentSource(apiSource, log, "UTF-8");
+        SpringMavenDocumentSource springMavenDocumentSource = new SpringMavenDocumentSource(apiSource, log, "UTF-8", "swagger", "2.0");
 
         Set<Class<?>> validClasses = springMavenDocumentSource.getValidClasses();
 


### PR DESCRIPTION
Added two options - `specification` and `specificationVersion` so that users can choose to have output in OpenAPI specification.