### PR TITLE
[JAX-RS] Generate tag with resource name for each operation

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/JaxrsReader.java
@@ -113,6 +113,9 @@ public class JaxrsReader extends AbstractReader implements ClassSwaggerReader {
         List<SecurityRequirement> securities = getSecurityRequirements(api);
         Map<String, Tag> discoveredTags = scanClasspathForTags();
 
+        final String resourceClassNameTag = cls.getSimpleName();
+        tags.put(resourceClassNameTag, new Tag().name(resourceClassNameTag));
+
         // merge consumes, produces
 
         readCommonParameters(cls);


### PR DESCRIPTION
Added an additional tag for each operation containing the class name of the resource where it is defined. 

This could come handy when used together with `openapi-generator` and its capability to group operations into resource classes for Jax-Rs.

It does not seem like a breaking change to me (tags are nothing but a metadata), so targeting `master`.