### PR TITLE
fix: set default for field ApiSource.outputFormats.

### DIFF
--- a/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiSource.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/mavenplugin/ApiSource.java
@@ -66,7 +66,7 @@ public class ApiSource {
     private String outputPath;
 
     @Parameter(defaultValue = "json")
-    private String outputFormats;
+    private String outputFormats = "json";
 
     @Parameter
     private String swaggerDirectory;


### PR DESCRIPTION
when outputFormats is null but not set default value, it will happend NPE.