### PR TITLE
Fixes #832 do not add definitions for excluded methods

### DIFF
--- a/src/test/java/com/wordnik/jaxrs/ParentResource.java
+++ b/src/test/java/com/wordnik/jaxrs/ParentResource.java
@@ -5,8 +5,12 @@
  */
 package com.wordnik.jaxrs;
 
+import java.sql.SQLException;
+
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+
+import javax.net.ssl.SSLException;
 import javax.ws.rs.Path;
 
 /**
@@ -20,5 +24,15 @@ public class ParentResource {
     @ApiOperation(value="SubResource")
     public SubResource getStudyResource() {
         return new SubResource();
+    }
+
+    // this static method and return type should not be included in the swagger as there is no Path nor Api
+    public static SQLException getCauseSQLException(Throwable e) {
+        return null;
+    }
+
+    // this method and return type should not be included in the swagger as there is no Path nor Api
+    public SSLException getCauseSSLException(Throwable e) {
+        return null;
     }
 }


### PR DESCRIPTION
In some cases the method will be excluded from the swagger (because it
misses httpMethod or Api annotation), but the return type of the method
is added to the definitions as parseMethod() had side effect and
modified the swagger.model object.

Removed the side effect of parseMethod().