### PR TITLE
Introducing api reader that extends rest api endpoint description with the permissions details that given endpoint requires.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
         <commons-io.version>2.0.1</commons-io.version>
         <reflections.version>0.9.9</reflections.version>
         <springframework.version>4.3.7.RELEASE</springframework.version>
+        <springframework.security.version>5.5.1</springframework.security.version>
         <commons-lang3.version>3.9</commons-lang3.version>
         <version.jersey-server>1.13</version.jersey-server>
         <version.javax.ws.rs-api>2.0.1</version.javax.ws.rs-api>
@@ -212,6 +213,11 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
             <version>${springframework.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+            <version>${springframework.security.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiWithAuthorizationReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiWithAuthorizationReader.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import java.lang.reflect.Method;
 import java.util.List;
 
+import static org.apache.commons.lang3.ObjectUtils.allNotNull;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.springframework.core.annotation.AnnotatedElementUtils.findMergedAnnotation;
 
@@ -36,15 +37,10 @@ public class SpringMvcApiWithAuthorizationReader extends SpringMvcApiReader {
         for (Method method : methods) {
             PreAuthorize preAuthorize = findMergedAnnotation(method, PreAuthorize.class);
             RequestMapping requestMapping = findMergedAnnotation(method, RequestMapping.class);
-            if (preAuthorize == null) continue; // nothing to update
-            if (requestMapping == null) continue; // nothing to update
-
             String resourcePathKey = resource.getControllerMapping() + resource.getResourceName();
             Path path = extSwagger.getPath(resourcePathKey);
-            if (path == null) continue; // nothing to update
-
             String permissions = preAuthorize.value();
-            if (isBlank(permissions)) continue; // nothing to update
+            if (!allNotNull(preAuthorize, requestMapping, path) || isBlank(permissions)) continue; // nothing to update
 
             for (RequestMethod reqMethod : requestMapping.method()) {
                 Operation operation = operation(path, reqMethod);

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiWithAuthorizationReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiWithAuthorizationReader.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.apache.commons.lang3.ObjectUtils.allNotNull;
@@ -42,10 +43,9 @@ public class SpringMvcApiWithAuthorizationReader extends SpringMvcApiReader {
             String permissions = preAuthorize.value();
             if (!allNotNull(preAuthorize, requestMapping, path) || isBlank(permissions)) continue; // nothing to update
 
-            for (RequestMethod reqMethod : requestMapping.method()) {
-                Operation operation = operation(path, reqMethod);
-                updateOperation(operation, permissions);
-            }
+            Arrays.stream(requestMapping.method())
+                    .map(reqMethod -> operation(path, reqMethod))
+                    .forEach(operation -> updateOperation(operation, permissions));
         }
 
         return extSwagger;

--- a/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiWithAuthorizationReader.java
+++ b/src/main/java/com/github/kongchen/swagger/docgen/reader/SpringMvcApiWithAuthorizationReader.java
@@ -1,0 +1,83 @@
+package com.github.kongchen.swagger.docgen.reader;
+
+import com.github.kongchen.swagger.docgen.spring.SpringResource;
+import io.swagger.models.Operation;
+import io.swagger.models.Path;
+import io.swagger.models.Swagger;
+import org.apache.maven.plugin.logging.Log;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.springframework.core.annotation.AnnotatedElementUtils.findMergedAnnotation;
+
+/**
+ * Extends rest api endpoint description with the permissions details that given endpoint requires.
+ *
+ * This swagger reader is used as {@code swaggerApiReader} property of the {@code swagger-maven-plugin}.
+ */
+public class SpringMvcApiWithAuthorizationReader extends SpringMvcApiReader {
+
+    private static final String PERMISSIONS_LABEL = "\n\n**Required Permissions**:\n\n";
+
+    public SpringMvcApiWithAuthorizationReader(Swagger swagger, Log log) {
+        super(swagger, log);
+    }
+
+    @Override
+    public Swagger read(SpringResource resource) {
+        Swagger extSwagger = super.read(resource);
+
+        List<Method> methods = resource.getMethods();
+        for (Method method : methods) {
+            PreAuthorize preAuthorize = findMergedAnnotation(method, PreAuthorize.class);
+            RequestMapping requestMapping = findMergedAnnotation(method, RequestMapping.class);
+            if (preAuthorize == null) continue; // nothing to update
+            if (requestMapping == null) continue; // nothing to update
+
+            String resourcePathKey = resource.getControllerMapping() + resource.getResourceName();
+            Path path = extSwagger.getPath(resourcePathKey);
+            if (path == null) continue; // nothing to update
+
+            String permissions = preAuthorize.value();
+            if (isBlank(permissions)) continue; // nothing to update
+
+            for (RequestMethod reqMethod : requestMapping.method()) {
+                Operation operation = operation(path, reqMethod);
+                updateOperation(operation, permissions);
+            }
+        }
+
+        return extSwagger;
+    }
+
+    private static Operation operation(Path path, RequestMethod method) {
+        switch (method) {
+            case POST:
+                return path.getPost();
+            case GET:
+                return path.getGet();
+            case PUT:
+                return path.getPut();
+            case DELETE:
+                return path.getDelete();
+            case HEAD:
+                return path.getHead();
+            case OPTIONS:
+                return path.getOptions();
+            case PATCH:
+                return path.getPatch();
+            default:
+                throw new IllegalArgumentException("could not find operation for method " + method);
+        }
+    }
+
+    private static void updateOperation(Operation operation, String permissions) {
+        String updatedDescription = operation.getDescription() + PERMISSIONS_LABEL + permissions;
+        operation.description(updatedDescription);
+    }
+}


### PR DESCRIPTION
Using given reader the generated API documentation will add information about required permissions. Like on the picture below.
![api with premissions info](https://user-images.githubusercontent.com/9861391/124137541-0f2cd000-da86-11eb-9212-411d2bb2e8e2.png)

The implementation does not have any permission extraction as the value of `@PreAuthorize` may contains also some custom expressions.  E.g. `@PreAuthorize("hasAuthority('FOO_BLA_READER') or evaluatesToTrue(#form.canReadFooBla)")`
In such case generated documentation presents following:
![api with premissions info 2](https://user-images.githubusercontent.com/9861391/124139062-8a42b600-da87-11eb-8c29-6f375aff0909.png)
Which still seems to be some hint of what is required to be successfully authorized.
