### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <swagger.version>1.5.21</swagger.version>
         <jackson.version>2.8.9</jackson.version>
         <log4j.version>1.2.16</log4j.version>
-        <handlebars.version>1.3.2</handlebars.version>
+        <handlebars.version>4.3.0</handlebars.version>
         <commons-io.version>2.0.1</commons-io.version>
         <reflections.version>0.9.9</reflections.version>
         <springframework.version>4.3.7.RELEASE</springframework.version>


### PR DESCRIPTION
-Versions of handlebars prior to 4.3.0 are vulnerable to prototype pollution leading to remote code execution. templates may alter an object's __proto__ and __definegetter__ properties, which may allow an attacker to execute arbitrary code through crafted payloads.
https://github.com/advisories/GHSA-w457-6q6x-cgp9
-CVEs
CVE-2019-19919
CVSS V2: 7.5/CVSS:2.0/AV:N/AC:L/Au:N/C:P/I:P/A:P
CVSS V3: 9.8/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H