### PR TITLE
Updated swagger-core to version 1.6.1 to support 'parseValue' in 'extensions'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,8 @@
 
         <!-- Dependency versions -->
         <maven.version>2.2.1</maven.version>
-        <swagger.version>1.5.21</swagger.version>
-        <jackson.version>2.8.9</jackson.version>
+        <swagger.version>1.6.1</swagger.version>
+        <jackson.version>2.10.5</jackson.version>
         <log4j.version>1.2.16</log4j.version>
         <handlebars.version>1.3.2</handlebars.version>
         <commons-io.version>2.0.1</commons-io.version>
@@ -72,7 +72,7 @@
         <commons-lang3.version>3.9</commons-lang3.version>
         <version.jersey-server>1.13</version.jersey-server>
         <version.javax.ws.rs-api>2.0.1</version.javax.ws.rs-api>
-        <version.maven-plugin-annotations>3.3</version.maven-plugin-annotations>
+        <version.maven-plugin-annotations>3.6.2</version.maven-plugin-annotations>
         <!-- Test dependency versions -->
         <maven-testing-harness.version>1.3</maven-testing-harness.version>
         <testng.version>6.8.8</testng.version>
@@ -86,14 +86,14 @@
         <version.maven-release-plugin>2.5.3</version.maven-release-plugin>
         <version.plexus-component-metadata>1.5.5</version.plexus-component-metadata>
         <version.maven-compiler-plugin>2.3.2</version.maven-compiler-plugin>
-        <version.maven-plugin-plugin>3.3</version.maven-plugin-plugin>
+        <version.maven-plugin-plugin>3.6.2</version.maven-plugin-plugin>
         <version.animal-sniffer-plugin>1.14</version.animal-sniffer-plugin>
         <version.maven-source-plugin>2.1.2</version.maven-source-plugin>
         <version.maven-javadoc-plugin>2.7</version.maven-javadoc-plugin>
         <version.maven-gpg-plugin>1.6</version.maven-gpg-plugin>
         <version.plexus-javadoc>1.0</version.plexus-javadoc>
         <version.slf4j-nop>1.7.25</version.slf4j-nop>
-        <kotlin.version>1.2.61</kotlin.version>
+        <kotlin.version>1.6.10</kotlin.version>
     </properties>
 
     <dependencies>

--- a/src/test/java/com/wordnik/sample/model/User.java
+++ b/src/test/java/com/wordnik/sample/model/User.java
@@ -110,7 +110,8 @@ public class User {
     }
 
     @XmlElement(name = "userStatus")
-    @ApiModelProperty(value = "User Status", allowableValues = "1-registered,2-active,3-closed", example = "2")
+    @ApiModelProperty(value = "User Status", allowableValues = "1-registered,2-active,3-closed", example = "2",
+      extensions = @Extension(properties = {@ExtensionProperty(name = "nested", parseValue = true, value = "{\"field1\": 1, \"field2\": [2,3], \"field3\": \"value3\" }")}))
     public int getUserStatus() {
         return userStatus;
     }

--- a/src/test/resources/expectedOutput/swagger-enhanced-operation-id.json
+++ b/src/test/resources/expectedOutput/swagger-enhanced-operation-id.json
@@ -1593,7 +1593,8 @@
           "type" : "integer",
           "format" : "int32",
           "example" : 2,
-          "description" : "User Status"
+          "description" : "User Status",
+          "x-nested": {"field1": 1, "field2": [2,3], "field3": "value3" }
         }
       },
       "xml" : {

--- a/src/test/resources/expectedOutput/swagger-externalDocs.json
+++ b/src/test/resources/expectedOutput/swagger-externalDocs.json
@@ -1953,7 +1953,8 @@
           "type": "integer",
           "format": "int32",
           "example": 2,
-          "description": "User Status"
+          "description": "User Status",
+          "x-nested": {"field1": 1, "field2": [2,3], "field3": "value3" }
         }
       },
       "xml": {

--- a/src/test/resources/expectedOutput/swagger-spring-enhanced-operation-id.json
+++ b/src/test/resources/expectedOutput/swagger-spring-enhanced-operation-id.json
@@ -1641,7 +1641,8 @@
           "type" : "integer",
           "format" : "int32",
           "example" : 2,
-          "description" : "User Status"
+          "description" : "User Status",
+          "x-nested": {"field1": 1, "field2": [2,3], "field3": "value3" }
         }
       },
       "xml" : {

--- a/src/test/resources/expectedOutput/swagger-spring.json
+++ b/src/test/resources/expectedOutput/swagger-spring.json
@@ -1641,7 +1641,8 @@
           "type" : "integer",
           "format" : "int32",
           "example" : 2,
-          "description" : "User Status"
+          "description" : "User Status",
+          "x-nested": {"field1": 1, "field2": [2,3], "field3": "value3" }
         }
       },
       "xml" : {

--- a/src/test/resources/expectedOutput/swagger-spring.yaml
+++ b/src/test/resources/expectedOutput/swagger-spring.yaml
@@ -1410,6 +1410,10 @@ definitions:
         format: "int32"
         example: 2
         description: "User Status"
+        x-nested:
+          field1: 1
+          field2: [ 2,3 ]
+          field3: "value3"
     xml:
       name: "User"
       namespace: "http://com.wordnik/sample/model"

--- a/src/test/resources/expectedOutput/swagger-swaggerreader.json
+++ b/src/test/resources/expectedOutput/swagger-swaggerreader.json
@@ -1445,7 +1445,8 @@
           "type" : "integer",
           "format" : "int32",
           "example" : 2,
-          "description" : "User Status"
+          "description" : "User Status",
+          "x-nested": {"field1": 1, "field2": [2,3], "field3": "value3" }
         }
       },
       "xml" : {

--- a/src/test/resources/expectedOutput/swagger-swaggerreader.yaml
+++ b/src/test/resources/expectedOutput/swagger-swaggerreader.yaml
@@ -1237,6 +1237,10 @@ definitions:
         format: "int32"
         example: 2
         description: "User Status"
+        x-nested:
+          field1: 1
+          field2: [ 2,3 ]
+          field3: "value3"
     xml:
       name: "User"
       namespace: "http://com.wordnik/sample/model"

--- a/src/test/resources/expectedOutput/swagger-with-converter.json
+++ b/src/test/resources/expectedOutput/swagger-with-converter.json
@@ -1948,7 +1948,8 @@
           "type": "integer",
           "format": "int32",
           "example": 2,
-          "description": "User Status"
+          "description": "User Status",
+          "x-nested": {"field1": 1, "field2": [2,3], "field3": "value3" }
         }
       },
       "xml": {

--- a/src/test/resources/expectedOutput/swagger-with-converter.yaml
+++ b/src/test/resources/expectedOutput/swagger-with-converter.yaml
@@ -1382,6 +1382,10 @@ definitions:
         format: "int32"
         example: 2
         description: "User Status"
+        x-nested:
+          field1: 1
+          field2: [ 2,3 ]
+          field3: "value3"
     xml:
       name: "User"
       namespace: "http://com.wordnik/sample/model"

--- a/src/test/resources/expectedOutput/swagger.json
+++ b/src/test/resources/expectedOutput/swagger.json
@@ -1953,7 +1953,8 @@
           "type": "integer",
           "format": "int32",
           "example": 2,
-          "description": "User Status"
+          "description": "User Status",
+          "x-nested": {"field1": 1, "field2": [2,3], "field3": "value3" }
         }
       },
       "xml": {

--- a/src/test/resources/expectedOutput/swagger.yaml
+++ b/src/test/resources/expectedOutput/swagger.yaml
@@ -1382,6 +1382,10 @@ definitions:
         format: "int32"
         example: 2
         description: "User Status"
+        x-nested:
+          field1: 1
+          field2: [ 2,3 ]
+          field3: "value3"
     xml:
       name: "User"
       namespace: "http://com.wordnik/sample/model"

--- a/src/test/resources/options/jsonExampleValues/expected/swagger-spring.json
+++ b/src/test/resources/options/jsonExampleValues/expected/swagger-spring.json
@@ -1071,7 +1071,8 @@
           "type" : "integer",
           "format" : "int32",
           "example" : 2,
-          "description" : "User Status"
+          "description" : "User Status",
+          "x-nested": {"field1": 1, "field2": [2,3], "field3": "value3" }
         }
       },
       "xml" : {

--- a/src/test/resources/options/jsonExampleValues/expected/swagger.json
+++ b/src/test/resources/options/jsonExampleValues/expected/swagger.json
@@ -960,7 +960,8 @@
           "type" : "integer",
           "format" : "int32",
           "example" : 2,
-          "description" : "User Status"
+          "description" : "User Status",
+          "x-nested": {"field1": 1, "field2": [2,3], "field3": "value3" }
         }
       },
       "xml" : {


### PR DESCRIPTION
In version 1.6.1 `swagger-core` (and `swagger-annotations`) added support for the `parseValue` property as part of the `@ExtensionProperty` annotation.
If `parseValue` is `true` the provided value is treated as json and it's parsed into the generated OpenAPI file as a nested object or an array (instead of as a string).

In this PR I upgraded the `swagger-core` library from `1.5.21` to `1.6.1` and updated the relevant tests (same as in https://github.com/kongchen/swagger-maven-plugin/pull/582/files).

I also upgraded other libraries to try to make `mvn install` work (but it doesn't) and run the tests in Intellij (that works), so these changes might not be needed if `mvn install` works in the CI.
I was able to make `mvn install -DskipTests` work with the additional libraries upgrades only if I manually disable the `check-java16-sun` execution (in `animal-sniffer-maven-plugin`).
Please let me know if you want to keep these additional upgrades or remove them.