### PR TITLE
replace log4j:1.2 by non vulnerable reload4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <!-- Test dependency versions -->
         <maven-testing-harness.version>1.3</maven-testing-harness.version>
         <testng.version>6.8.8</testng.version>
-        <jettison.version>1.3.3</jettison.version>
+        <jettison.version>1.5.4</jettison.version>
         <json-unit.version>1.17.0</json-unit.version>
         <version.mockito-core>2.18.3</version.mockito-core>
         <version.hamcrest-library>1.3</version.hamcrest-library>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <commons-io.version>2.0.1</commons-io.version>
         <reflections.version>0.9.9</reflections.version>
         <springframework.version>6.0.0</springframework.version>
-        <commons-lang3.version>3.9</commons-lang3.version>
+        <commons-lang3.version>3.18.0</commons-lang3.version>
         <version.jersey-server>1.13</version.jersey-server>
         <version.javax.ws.rs-api>2.0.1</version.javax.ws.rs-api>
         <version.maven-plugin-annotations>3.3</version.maven-plugin-annotations>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <jackson.version>2.12.7.1</jackson.version>
         <reload4j.version>1.2.20</reload4j.version>
         <handlebars.version>1.3.2</handlebars.version>
-        <commons-io.version>2.0.1</commons-io.version>
+        <commons-io.version>2.14.0</commons-io.version>
         <reflections.version>0.9.9</reflections.version>
         <springframework.version>6.0.0</springframework.version>
         <commons-lang3.version>3.9</commons-lang3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <sonatypeOssDistMgmtSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</sonatypeOssDistMgmtSnapshotsUrl>
 
         <!-- Dependency versions -->
-        <maven.version>2.2.1</maven.version>
+        <maven.version>3.8.1</maven.version>
         <swagger.version>1.5.21</swagger.version>
         <jackson.version>2.12.7.1</jackson.version>
         <reload4j.version>1.2.20</reload4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <!-- Dependency versions -->
         <maven.version>2.2.1</maven.version>
         <swagger.version>1.5.21</swagger.version>
-        <jackson.version>2.8.9</jackson.version>
+        <jackson.version>2.12.7.1</jackson.version>
         <reload4j.version>1.2.20</reload4j.version>
         <handlebars.version>1.3.2</handlebars.version>
         <commons-io.version>2.0.1</commons-io.version>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <handlebars.version>1.3.2</handlebars.version>
         <commons-io.version>2.0.1</commons-io.version>
         <reflections.version>0.9.9</reflections.version>
-        <springframework.version>4.3.7.RELEASE</springframework.version>
+        <springframework.version>6.1.20</springframework.version>
         <commons-lang3.version>3.9</commons-lang3.version>
         <version.jersey-server>1.13</version.jersey-server>
         <version.javax.ws.rs-api>2.0.1</version.javax.ws.rs-api>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <!-- Dependency versions -->
         <maven.version>2.2.1</maven.version>
         <swagger.version>1.5.21</swagger.version>
-        <jackson.version>2.12.7.1</jackson.version>
+        <jackson.version>2.15.0</jackson.version>
         <reload4j.version>1.2.20</reload4j.version>
         <handlebars.version>1.3.2</handlebars.version>
         <commons-io.version>2.0.1</commons-io.version>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <handlebars.version>1.3.2</handlebars.version>
         <commons-io.version>2.0.1</commons-io.version>
         <reflections.version>0.9.9</reflections.version>
-        <springframework.version>4.3.7.RELEASE</springframework.version>
+        <springframework.version>6.0.0</springframework.version>
         <commons-lang3.version>3.9</commons-lang3.version>
         <version.jersey-server>1.13</version.jersey-server>
         <version.javax.ws.rs-api>2.0.1</version.javax.ws.rs-api>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <maven.version>2.2.1</maven.version>
         <swagger.version>1.5.21</swagger.version>
         <jackson.version>2.8.9</jackson.version>
-        <log4j.version>1.2.16</log4j.version>
+        <reload4j.version>1.2.20</reload4j.version>
         <handlebars.version>1.3.2</handlebars.version>
         <commons-io.version>2.0.1</commons-io.version>
         <reflections.version>0.9.9</reflections.version>
@@ -172,9 +172,9 @@
             <version>${commons-io.version}</version>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>${log4j.version}</version>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
+            <version>${reload4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
swagger-maven-plugin keeps gettings back log4j:1.2.16 in my local repo and breaches company security rules.
reload4j is binary compatible with log4j but fixes the important CVEs.